### PR TITLE
Process save figures

### DIFF
--- a/magtogoek/adcp/adcp_plots.py
+++ b/magtogoek/adcp/adcp_plots.py
@@ -53,7 +53,8 @@ def make_adcp_figure(dataset: xr.Dataset,
                      flag_thres: int = 2,
                      vel_only: bool = False,
                      path: str = None,
-                     save: bool = False):
+                     save: bool = False,
+                     show: bool = True):
     """
 
     Looks for 'ancillary_variables' attributes on variables for QC flagging.
@@ -68,7 +69,9 @@ def make_adcp_figure(dataset: xr.Dataset,
     vel_only :
         Make only velocity data figures.
     save :
-        Write figures to file next to data output.
+        Write figures to file.
+    show :
+        Display figures on screen.
 
     Returns
     -------
@@ -116,7 +119,7 @@ def make_adcp_figure(dataset: xr.Dataset,
         figs.append(plot_test_fields(dataset))
         names.append('test_fields')
 
-    if single is True:
+    if single is True and show is True:
         for count, fig in enumerate(figs):
             fig.show()
             input(f"({count + 1}/{len(figs)}) Press [enter] to plot the next figure.\033[1A \033[9C")
@@ -127,7 +130,8 @@ def make_adcp_figure(dataset: xr.Dataset,
         for name, fig in zip(names, figs):
             fig.savefig(f'{path}{name}.png')
 
-    plt.show()
+    if show is True:
+        plt.show()
 
 
 def plot_velocity_polar_hist(dataset: xr.Dataset, nrows: int = 3, ncols: int = 3,

--- a/magtogoek/adcp/adcp_plots.py
+++ b/magtogoek/adcp/adcp_plots.py
@@ -54,7 +54,7 @@ def make_adcp_figure(dataset: xr.Dataset,
                      vel_only: bool = False,
                      path: str = None,
                      save: bool = False,
-                     show: bool = True):
+                     headless: bool = False):
     """
 
     Looks for 'ancillary_variables' attributes on variables for QC flagging.
@@ -70,8 +70,8 @@ def make_adcp_figure(dataset: xr.Dataset,
         Make only velocity data figures.
     save :
         Write figures to file.
-    show :
-        Display figures on screen.
+    headless :
+        Disable figure display when True.
 
     Returns
     -------
@@ -119,7 +119,7 @@ def make_adcp_figure(dataset: xr.Dataset,
         figs.append(plot_test_fields(dataset))
         names.append('test_fields')
 
-    if single is True and show is True:
+    if single is True and headless is False:
         for count, fig in enumerate(figs):
             fig.show()
             input(f"({count + 1}/{len(figs)}) Press [enter] to plot the next figure.\033[1A \033[9C")
@@ -130,7 +130,8 @@ def make_adcp_figure(dataset: xr.Dataset,
         for name, fig in zip(names, figs):
             fig.savefig(f'{path}{name}.png')
 
-    if show is True:
+    print("JUST BEFORE SHOW", headless)
+    if headless is False:
         plt.show()
 
 

--- a/magtogoek/adcp/adcp_plots.py
+++ b/magtogoek/adcp/adcp_plots.py
@@ -22,7 +22,7 @@ import xarray as xr
 from magtogoek.plot_utils import grid_subplot
 from magtogoek.tools import round_up, flag_data, polar_histo
 
-#plt.switch_backend('Qt5Agg')
+# plt.switch_backend('Qt5Agg')
 
 FONT = {"family": "serif", "color": "darkred", "weight": "normal", "size": 12}
 BINARY_CMAP = plt.get_cmap("viridis_r", 2)
@@ -107,12 +107,16 @@ def make_adcp_figure(dataset: xr.Dataset,
             depths = dataset.depth.data[0:3]
             if dataset.attrs['orientation'] == "up":
                 depths = dataset.depth.data[-3:]
-            figs.append(plot_vel_series(dataset, depths=depths, uvw=uvw_var, flag_thres=flag_thres))
-            figs.append(plot_pearson_corr(dataset, uvw=uvw_var, flag_thres=flag_thres))
+            figs.append(plot_vel_series(dataset, depths=depths,
+                                        uvw=uvw_var, flag_thres=flag_thres))
+            figs.append(plot_pearson_corr(
+                dataset, uvw=uvw_var, flag_thres=flag_thres))
             names.extend(('vel_series', 'pearson_corr'))
 
-        figs.append(plot_velocity_polar_hist(dataset, nrows=2, ncols=3, uv=uvw_var[:2], flag_thres=flag_thres))
-        figs.append(plot_velocity_fields(dataset, uvw=uvw_var, flag_thres=flag_thres))
+        figs.append(plot_velocity_polar_hist(dataset, nrows=2,
+                                             ncols=3, uv=uvw_var[:2], flag_thres=flag_thres))
+        figs.append(plot_velocity_fields(
+            dataset, uvw=uvw_var, flag_thres=flag_thres))
         names.extend(('velocity_polar_hist', 'velocity_fields'))
 
     if "binary_mask" in dataset:
@@ -122,7 +126,8 @@ def make_adcp_figure(dataset: xr.Dataset,
     if single is True and show is True:
         for count, fig in enumerate(figs):
             fig.show()
-            input(f"({count + 1}/{len(figs)}) Press [enter] to plot the next figure.\033[1A \033[9C")
+            input(
+                f"({count + 1}/{len(figs)}) Press [enter] to plot the next figure.\033[1A \033[9C")
 
     if save is True:
         if path != '':
@@ -144,7 +149,8 @@ def plot_velocity_polar_hist(dataset: xr.Dataset, nrows: int = 3, ncols: int = 3
     r_max = round_up(r_max, 0.2)
     r_ticks = np.round(np.linspace(0, r_max, 6), 2)[1:]
 
-    bin_depths = np.linspace(dataset.depth.min(), dataset.depth.max(), naxes + 1)
+    bin_depths = np.linspace(
+        dataset.depth.min(), dataset.depth.max(), naxes + 1)
 
     fig, axes = plt.subplots(figsize=(12, 8), nrows=nrows, ncols=ncols,
                              subplot_kw={"projection": "polar"}, constrained_layout=True)
@@ -158,7 +164,8 @@ def plot_velocity_polar_hist(dataset: xr.Dataset, nrows: int = 3, ncols: int = 3
         if np.isfinite(histo).any():
             histo /= np.nanmax(histo)
             axes[index].grid(False)
-            axes[index].pcolormesh(a_edges, r_edges, histo.T, cmap=cmo.cm.amp, shading="flat")
+            axes[index].pcolormesh(
+                a_edges, r_edges, histo.T, cmap=cmo.cm.amp, shading="flat")
         axes[index].set_title(
             f"depth: {round((bin_depths[index] + bin_depths[index + 1]) / 2, 0)} m", fontdict=FONT, loc="left"
         )
@@ -172,7 +179,8 @@ def plot_velocity_polar_hist(dataset: xr.Dataset, nrows: int = 3, ncols: int = 3
         rlabels_tpos = np.arctan2(1.3 * r_max, r_ticks)
 
         for label, rpos, tpos, rtick in zip(r_ticks, rlabels_rpos, rlabels_tpos, r_ticks):
-            axes[index].text(tpos, rpos, f"{label:.2f}", fontsize=10, clip_on=False, va="center", rotation=0)
+            axes[index].text(
+                tpos, rpos, f"{label:.2f}", fontsize=10, clip_on=False, va="center", rotation=0)
             axes[index].plot(
                 (0, tpos), (rtick, rpos), "--", lw=0.6, c="k", clip_on=False
             )
@@ -214,13 +222,15 @@ def plot_test_fields(dataset: xr.Dataset):
     """
     """
     extent = get_extent(dataset)
-    fig, axes = plt.subplots(figsize=(12, 8), nrows=3, ncols=3, sharex=True, sharey=True)
+    fig, axes = plt.subplots(figsize=(12, 8), nrows=3,
+                             ncols=3, sharex=True, sharey=True)
     axes = axes.flatten()
     for index, test_name in enumerate(dataset.attrs["binary_mask_tests"]):
         value = dataset.attrs["binary_mask_tests_values"][index]
         if value is not None:
             mask = (dataset.binary_mask.astype(int) & 2 ** index).astype(bool)
-            axes[index].imshow(mask, aspect="auto", cmap=BINARY_CMAP, extent=extent, interpolation='none', )
+            axes[index].imshow(mask, aspect="auto", cmap=BINARY_CMAP,
+                               extent=extent, interpolation='none', )
             axes[index].xaxis_date()
             axes[index].set_title(test_name + f": {value}", fontdict=FONT)
         axes[index].tick_params(labelleft=False, labelbottom=False)
@@ -242,7 +252,8 @@ def plot_test_fields(dataset: xr.Dataset):
 
 def plot_vel_series(dataset: xr.Dataset, depths: Union[float, List[float]],
                     uvw: List[str] = ("u", "v", "w"), flag_thres: int = 2):
-    fig, axes = plt.subplots(figsize=(12, 8), nrows=3, ncols=1, sharex=True, sharey=True)
+    fig, axes = plt.subplots(figsize=(12, 8), nrows=3,
+                             ncols=1, sharex=True, sharey=True)
     axes[0].tick_params(labelbottom=False)
     axes[1].tick_params(labelbottom=False)
 
@@ -251,7 +262,8 @@ def plot_vel_series(dataset: xr.Dataset, depths: Union[float, List[float]],
         da = flag_data(dataset=dataset, var=var, flag_thres=flag_thres)
         clines = cycle(["solid", "dotted", "dashed", "dashdotted"])
         for depth, c in zip(depths, colors):
-            ax.plot(dataset.time, da.sel(depth=depth), linestyle=next(clines), c=c, label=str(depth) + " m")
+            ax.plot(dataset.time, da.sel(depth=depth), linestyle=next(
+                clines), c=c, label=str(depth) + " m")
         ax.set_ylabel(f"{var}\n[{dataset[var].units}]", fontdict=FONT)
     axes[2].set_xlabel("time", fontdict=FONT)
     axes[2].legend(title="depth")
@@ -281,13 +293,14 @@ def plot_pearson_corr(dataset: xr.Dataset, uvw: List[str] = ("u", "v", "w"), fla
 
 def plot_sensor_data(dataset: xr.Dataset, varnames: List[str], flag_thres: int = 2):
     varnames = [var for var in varnames if var in dataset.variables]
-    fig, axes = plt.subplots(figsize=(12, 8), nrows=len(varnames), ncols=1, sharex=True, squeeze=False)
+    fig, axes = plt.subplots(figsize=(12, 8), nrows=len(
+        varnames), ncols=1, sharex=True, squeeze=False)
     axes = axes.flatten()
     for var, ax in zip(varnames, axes):
         da = dataset[var]
         if 'ancillary_variables' in dataset[var].attrs:
             if dataset[var].attrs['ancillary_variables'] in dataset:
-                da=flag_data(dataset, var=var, flag_thres=flag_thres)
+                da = flag_data(dataset, var=var, flag_thres=flag_thres)
         ax.plot(dataset.time, da)
         ax.set_ylabel(f"{var}\n[{dataset[var].units}]", fontdict=FONT)
         ax.tick_params(labelbottom=False)
@@ -298,7 +311,8 @@ def plot_sensor_data(dataset: xr.Dataset, varnames: List[str], flag_thres: int =
 
 
 def plot_bt_vel(dataset: xr.Dataset, uvw: List[str] = ("bt_u", "bt_v", "bt_w")):
-    fig, axes = plt.subplots(figsize=(12, 8), nrows=3, ncols=1, sharex=True, sharey=True)
+    fig, axes = plt.subplots(figsize=(12, 8), nrows=3,
+                             ncols=1, sharex=True, sharey=True)
     axes[0].tick_params(labelbottom=False)
     axes[1].tick_params(labelbottom=False)
     for var, ax in zip(uvw, axes):
@@ -331,6 +345,7 @@ if __name__ == "__main__":
     ]
     _dataset = xr.open_dataset(nc_file)
     _dataset.attrs["binary_mask_tests"] = test
-    _dataset.attrs["binary_mask_tests_values"] = [0, 64, 90, 5.0, 5.0, 5.0, 20, 20, None]
+    _dataset.attrs["binary_mask_tests_values"] = [
+        0, 64, 90, 5.0, 5.0, 5.0, 20, 20, None]
 
     make_adcp_figure(_dataset, single=False)

--- a/magtogoek/adcp/adcp_plots.py
+++ b/magtogoek/adcp/adcp_plots.py
@@ -130,7 +130,6 @@ def make_adcp_figure(dataset: xr.Dataset,
         for name, fig in zip(names, figs):
             fig.savefig(f'{path}{name}.png')
 
-    print("JUST BEFORE SHOW", headless)
     if headless is False:
         plt.show()
 

--- a/magtogoek/adcp/adcp_plots.py
+++ b/magtogoek/adcp/adcp_plots.py
@@ -107,16 +107,12 @@ def make_adcp_figure(dataset: xr.Dataset,
             depths = dataset.depth.data[0:3]
             if dataset.attrs['orientation'] == "up":
                 depths = dataset.depth.data[-3:]
-            figs.append(plot_vel_series(dataset, depths=depths,
-                                        uvw=uvw_var, flag_thres=flag_thres))
-            figs.append(plot_pearson_corr(
-                dataset, uvw=uvw_var, flag_thres=flag_thres))
+            figs.append(plot_vel_series(dataset, depths=depths, uvw=uvw_var, flag_thres=flag_thres))
+            figs.append(plot_pearson_corr(dataset, uvw=uvw_var, flag_thres=flag_thres))
             names.extend(('vel_series', 'pearson_corr'))
 
-        figs.append(plot_velocity_polar_hist(dataset, nrows=2,
-                                             ncols=3, uv=uvw_var[:2], flag_thres=flag_thres))
-        figs.append(plot_velocity_fields(
-            dataset, uvw=uvw_var, flag_thres=flag_thres))
+        figs.append(plot_velocity_polar_hist(dataset, nrows=2, ncols=3, uv=uvw_var[:2], flag_thres=flag_thres))
+        figs.append(plot_velocity_fields(dataset, uvw=uvw_var, flag_thres=flag_thres))
         names.extend(('velocity_polar_hist', 'velocity_fields'))
 
     if "binary_mask" in dataset:
@@ -126,8 +122,7 @@ def make_adcp_figure(dataset: xr.Dataset,
     if single is True and show is True:
         for count, fig in enumerate(figs):
             fig.show()
-            input(
-                f"({count + 1}/{len(figs)}) Press [enter] to plot the next figure.\033[1A \033[9C")
+            input(f"({count + 1}/{len(figs)}) Press [enter] to plot the next figure.\033[1A \033[9C")
 
     if save is True:
         if path != '':
@@ -149,8 +144,7 @@ def plot_velocity_polar_hist(dataset: xr.Dataset, nrows: int = 3, ncols: int = 3
     r_max = round_up(r_max, 0.2)
     r_ticks = np.round(np.linspace(0, r_max, 6), 2)[1:]
 
-    bin_depths = np.linspace(
-        dataset.depth.min(), dataset.depth.max(), naxes + 1)
+    bin_depths = np.linspace(dataset.depth.min(), dataset.depth.max(), naxes + 1)
 
     fig, axes = plt.subplots(figsize=(12, 8), nrows=nrows, ncols=ncols,
                              subplot_kw={"projection": "polar"}, constrained_layout=True)
@@ -164,8 +158,7 @@ def plot_velocity_polar_hist(dataset: xr.Dataset, nrows: int = 3, ncols: int = 3
         if np.isfinite(histo).any():
             histo /= np.nanmax(histo)
             axes[index].grid(False)
-            axes[index].pcolormesh(
-                a_edges, r_edges, histo.T, cmap=cmo.cm.amp, shading="flat")
+            axes[index].pcolormesh(a_edges, r_edges, histo.T, cmap=cmo.cm.amp, shading="flat")
         axes[index].set_title(
             f"depth: {round((bin_depths[index] + bin_depths[index + 1]) / 2, 0)} m", fontdict=FONT, loc="left"
         )
@@ -179,8 +172,7 @@ def plot_velocity_polar_hist(dataset: xr.Dataset, nrows: int = 3, ncols: int = 3
         rlabels_tpos = np.arctan2(1.3 * r_max, r_ticks)
 
         for label, rpos, tpos, rtick in zip(r_ticks, rlabels_rpos, rlabels_tpos, r_ticks):
-            axes[index].text(
-                tpos, rpos, f"{label:.2f}", fontsize=10, clip_on=False, va="center", rotation=0)
+            axes[index].text(tpos, rpos, f"{label:.2f}", fontsize=10, clip_on=False, va="center", rotation=0)
             axes[index].plot(
                 (0, tpos), (rtick, rpos), "--", lw=0.6, c="k", clip_on=False
             )
@@ -222,15 +214,13 @@ def plot_test_fields(dataset: xr.Dataset):
     """
     """
     extent = get_extent(dataset)
-    fig, axes = plt.subplots(figsize=(12, 8), nrows=3,
-                             ncols=3, sharex=True, sharey=True)
+    fig, axes = plt.subplots(figsize=(12, 8), nrows=3, ncols=3, sharex=True, sharey=True)
     axes = axes.flatten()
     for index, test_name in enumerate(dataset.attrs["binary_mask_tests"]):
         value = dataset.attrs["binary_mask_tests_values"][index]
         if value is not None:
             mask = (dataset.binary_mask.astype(int) & 2 ** index).astype(bool)
-            axes[index].imshow(mask, aspect="auto", cmap=BINARY_CMAP,
-                               extent=extent, interpolation='none', )
+            axes[index].imshow(mask, aspect="auto", cmap=BINARY_CMAP, extent=extent, interpolation='none', )
             axes[index].xaxis_date()
             axes[index].set_title(test_name + f": {value}", fontdict=FONT)
         axes[index].tick_params(labelleft=False, labelbottom=False)
@@ -252,8 +242,7 @@ def plot_test_fields(dataset: xr.Dataset):
 
 def plot_vel_series(dataset: xr.Dataset, depths: Union[float, List[float]],
                     uvw: List[str] = ("u", "v", "w"), flag_thres: int = 2):
-    fig, axes = plt.subplots(figsize=(12, 8), nrows=3,
-                             ncols=1, sharex=True, sharey=True)
+    fig, axes = plt.subplots(figsize=(12, 8), nrows=3, ncols=1, sharex=True, sharey=True)
     axes[0].tick_params(labelbottom=False)
     axes[1].tick_params(labelbottom=False)
 
@@ -262,8 +251,7 @@ def plot_vel_series(dataset: xr.Dataset, depths: Union[float, List[float]],
         da = flag_data(dataset=dataset, var=var, flag_thres=flag_thres)
         clines = cycle(["solid", "dotted", "dashed", "dashdotted"])
         for depth, c in zip(depths, colors):
-            ax.plot(dataset.time, da.sel(depth=depth), linestyle=next(
-                clines), c=c, label=str(depth) + " m")
+            ax.plot(dataset.time, da.sel(depth=depth), linestyle=next(clines), c=c, label=str(depth) + " m")
         ax.set_ylabel(f"{var}\n[{dataset[var].units}]", fontdict=FONT)
     axes[2].set_xlabel("time", fontdict=FONT)
     axes[2].legend(title="depth")
@@ -293,8 +281,7 @@ def plot_pearson_corr(dataset: xr.Dataset, uvw: List[str] = ("u", "v", "w"), fla
 
 def plot_sensor_data(dataset: xr.Dataset, varnames: List[str], flag_thres: int = 2):
     varnames = [var for var in varnames if var in dataset.variables]
-    fig, axes = plt.subplots(figsize=(12, 8), nrows=len(
-        varnames), ncols=1, sharex=True, squeeze=False)
+    fig, axes = plt.subplots(figsize=(12, 8), nrows=len(varnames), ncols=1, sharex=True, squeeze=False)
     axes = axes.flatten()
     for var, ax in zip(varnames, axes):
         da = dataset[var]
@@ -311,8 +298,7 @@ def plot_sensor_data(dataset: xr.Dataset, varnames: List[str], flag_thres: int =
 
 
 def plot_bt_vel(dataset: xr.Dataset, uvw: List[str] = ("bt_u", "bt_v", "bt_w")):
-    fig, axes = plt.subplots(figsize=(12, 8), nrows=3,
-                             ncols=1, sharex=True, sharey=True)
+    fig, axes = plt.subplots(figsize=(12, 8), nrows=3, ncols=1, sharex=True, sharey=True)
     axes[0].tick_params(labelbottom=False)
     axes[1].tick_params(labelbottom=False)
     for var, ax in zip(uvw, axes):
@@ -345,7 +331,6 @@ if __name__ == "__main__":
     ]
     _dataset = xr.open_dataset(nc_file)
     _dataset.attrs["binary_mask_tests"] = test
-    _dataset.attrs["binary_mask_tests_values"] = [
-        0, 64, 90, 5.0, 5.0, 5.0, 20, 20, None]
+    _dataset.attrs["binary_mask_tests_values"] = [0, 64, 90, 5.0, 5.0, 5.0, 20, 20, None]
 
     make_adcp_figure(_dataset, single=False)

--- a/magtogoek/adcp/adcp_plots.py
+++ b/magtogoek/adcp/adcp_plots.py
@@ -52,9 +52,8 @@ def make_adcp_figure(dataset: xr.Dataset,
                      single: bool = False,
                      flag_thres: int = 2,
                      vel_only: bool = False,
-                     path: str = None,
-                     save: bool = False,
-                     headless: bool = False):
+                     save_path: str = None,
+                     show_fig: bool = True):
     """
 
     Looks for 'ancillary_variables' attributes on variables for QC flagging.
@@ -68,9 +67,9 @@ def make_adcp_figure(dataset: xr.Dataset,
         Value with QC flag of `flag_thres` or lower will be plotted ([0, ..., flag_thres])
     vel_only :
         Make only velocity data figures.
-    save :
+    save_path :
         Write figures to file.
-    headless :
+    show_fig :
         Disable figure display when True.
 
     Returns
@@ -119,19 +118,25 @@ def make_adcp_figure(dataset: xr.Dataset,
         figs.append(plot_test_fields(dataset))
         names.append('test_fields')
 
-    if single is True and headless is False:
+    if single is True and show_fig is True:
         for count, fig in enumerate(figs):
             fig.show()
             input(f"({count + 1}/{len(figs)}) Press [enter] to plot the next figure.\033[1A \033[9C")
 
-    if save is True:
-        if path != '':
-            path = f'{Path(path).stem}_'
+    if save_path is not None:
+        stem = ''
+        if Path(save_path).is_dir():
+            path = Path(save_path)
+        else:
+            path = Path(save_path).parent
+            stem = str(Path(save_path).stem) + '_'
         for name, fig in zip(names, figs):
-            fig.savefig(f'{path}{name}.png')
+            fig.savefig(path.joinpath(stem + f'{name}.png'))
 
-    if headless is False:
+    if show_fig is True:
         plt.show()
+    else:
+        plt.close('all')
 
 
 def plot_velocity_polar_hist(dataset: xr.Dataset, nrows: int = 3, ncols: int = 3,

--- a/magtogoek/adcp/process.py
+++ b/magtogoek/adcp/process.py
@@ -199,6 +199,7 @@ class ProcessConfig:
     sensor_id: str = None
     netcdf_output: tp.Union[str, bool] = None
     odf_output: tp.Union[str, bool] = None
+    figures_output: tp.Union[str, bool] = None
     yearbase: int = None
     adcp_orientation: str = None
     sonar: str = None
@@ -240,6 +241,7 @@ class ProcessConfig:
     netcdf_path: str = None
     odf_path: str = None
     log_path: str = None
+    figures_path: str = None
 
     grid_depth: str = None
     grid_method: str = None
@@ -452,7 +454,10 @@ def _process_adcp_data(pconfig: ProcessConfig):
     # ------------ #
 
     if pconfig.make_figures:
-        make_adcp_figure(dataset, flag_thres=2)
+        make_adcp_figure(dataset,
+                         flag_thres=2,
+                         path=pconfig.figures_path,
+                         save=pconfig.figures_output)
 
     dataset["time"].assign_attrs(TIME_ATTRS)
 
@@ -1022,6 +1027,22 @@ def _outputs_path_handler(pconfig: ProcessConfig):
         if not pconfig.netcdf_output:
             default_path = _odf_path.parent
             default_filename = _odf_path.stem
+
+    if isinstance(pconfig.make_figures, bool):
+        pconfig.figures_output = False
+    elif isinstance(pconfig.make_figures, str):
+        _figures_output = Path(pconfig.make_figures)
+        if Path(_figures_output.name) == _figures_output:
+            _figures_path = default_path.joinpath(_figures_output).resolve()
+        elif _odf_output.is_dir():
+            _figures_path = _figures_output
+        elif _odf_output.parent.is_dir():
+            _figures_path = _figures_output
+        else:
+            raise ValueError(f'Path to {_figures_output} does not exists.')
+
+        pconfig.figures_path = str(_figures_path)
+        pconfig.figures_output = True
 
     pconfig.log_path = str(default_path.joinpath(default_filename))
 

--- a/magtogoek/adcp/process.py
+++ b/magtogoek/adcp/process.py
@@ -492,7 +492,6 @@ def _process_adcp_data(pconfig: ProcessConfig):
     # ----------- #
     l.section("Post-processing")
     if pconfig.grid_depth != "":
-        print('IN REGRIDDING', pconfig.grid_depth)
         dataset = _regrid_dataset(dataset, pconfig)
 
     # ----------- #

--- a/magtogoek/adcp/process.py
+++ b/magtogoek/adcp/process.py
@@ -491,7 +491,7 @@ def _process_adcp_data(pconfig: ProcessConfig):
     # RE-GRIDDING #
     # ----------- #
     l.section("Post-processing")
-    if pconfig.grid_depth is not None:
+    if pconfig.grid_depth != "":
         dataset = _regrid_dataset(dataset, pconfig)
 
     # ----------- #

--- a/magtogoek/adcp/process.py
+++ b/magtogoek/adcp/process.py
@@ -461,7 +461,6 @@ def _process_adcp_data(pconfig: ProcessConfig):
     # ------------ #
     # MAKE FIGURES #
     # ------------ #
-    print(pconfig.figures_output, pconfig.figures_path, pconfig.headless)
     if pconfig.figures_output is True:
         make_adcp_figure(dataset,
                          flag_thres=2,

--- a/magtogoek/adcp/process.py
+++ b/magtogoek/adcp/process.py
@@ -99,8 +99,7 @@ GLOBAL_ATTRS_TO_DROP = [
     "binary_mask_tests_values",
     "bodc_name"
 ]
-CONFIG_GLOBAL_ATTRS_SECTIONS = ["NETCDF_CF",
-                                "PROJECT", "CRUISE", "GLOBAL_ATTRIBUTES"]
+CONFIG_GLOBAL_ATTRS_SECTIONS = ["NETCDF_CF", "PROJECT", "CRUISE", "GLOBAL_ATTRIBUTES"]
 PLATFORM_TYPES = ["buoy", "mooring", "ship"]
 DEFAULT_PLATFORM_TYPE = "buoy"
 DATA_TYPES = {"buoy": "madcp", "mooring": "madcp", "ship": "adcp"}
@@ -281,8 +280,7 @@ class ProcessConfig:
     def _get_platform_metadata(self):
         if self.platform_file is not None:
             if Path(self.platform_file).is_file():
-                self.platform_metadata = _load_platform(
-                    self.platform_file, self.platform_id, self.sensor_id)
+                self.platform_metadata = _load_platform(self.platform_file, self.platform_id, self.sensor_id)
             else:
                 l.warning(f"platform_file, {self.platform_file}, not found")
         elif self.platform_type is not None:
@@ -291,10 +289,8 @@ class ProcessConfig:
                 self.platform_metadata["platform"]['platform_type'] = self.platform_type
             else:
                 self.platform_metadata["platform"]['platform_type'] = DEFAULT_PLATFORM_TYPE
-                l.warning(
-                    f"platform_type invalid or no specified. Must be one of {PLATFORM_TYPES}")
-                l.warning(
-                    f"platform_type set to `{DEFAULT_PLATFORM_TYPE}` for platform_type.")
+                l.warning(f"platform_type invalid or no specified. Must be one of {PLATFORM_TYPES}")
+                l.warning(f"platform_type set to `{DEFAULT_PLATFORM_TYPE}` for platform_type.")
 
 
 def process_adcp(config: dict,
@@ -315,11 +311,9 @@ def process_adcp(config: dict,
     The actual data processing is carried out by _process_adcp_data.
     """
     pconfig = ProcessConfig(config)
-    print("Top of process_adcp", pconfig.showfig)
     pconfig.drop_empty_attrs = drop_empty_attrs
     if showfig is not None:
         pconfig.showfig = showfig
-    print("Still in process_adcp", pconfig.showfig)
 
     if pconfig.merge_output_files:
         _process_adcp_data(pconfig)
@@ -331,14 +325,11 @@ def process_adcp(config: dict,
                 if isinstance(netcdf_output, bool):
                     pconfig.netcdf_output = filename
                 else:
-                    pconfig.netcdf_output = Path(
-                        netcdf_output).absolute().resolve()
+                    pconfig.netcdf_output = Path(netcdf_output).absolute().resolve()
                     if pconfig.netcdf_output.is_dir():
-                        pconfig.netcdf_output = str(
-                            pconfig.netcdf_output.joinpath(filename))
+                        pconfig.netcdf_output = str(pconfig.netcdf_output.joinpath(filename))
                     else:
-                        pconfig.netcdf_output = str(
-                            pconfig.netcdf_output.with_suffix("")) + f"_{count}"
+                        pconfig.netcdf_output = str(pconfig.netcdf_output.with_suffix("")) + f"_{count}"
             pconfig.input_files = [filename]
 
             _process_adcp_data(pconfig)
@@ -399,8 +390,7 @@ def _process_adcp_data(pconfig: ProcessConfig):
 
     if pconfig.platform_metadata["platform"]["platform_type"] in ["mooring", "buoy"]:
         if "bt_depth" in dataset:
-            dataset.attrs["sounding"] = np.round(
-                np.median(dataset.bt_depth.data), 2)
+            dataset.attrs["sounding"] = np.round(np.median(dataset.bt_depth.data), 2)
 
     _set_xducer_depth_as_sensor_depth(dataset)
 
@@ -431,21 +421,17 @@ def _process_adcp_data(pconfig: ProcessConfig):
     l.section("Data transformation")
 
     if dataset.attrs['magnetic_declination'] is not None:
-        l.log(
-            f"Magnetic declination found in the raw file: {dataset.attrs['magnetic_declination']} degree east.")
+        l.log(f"Magnetic declination found in the raw file: {dataset.attrs['magnetic_declination']} degree east.")
     else:
         l.log(f"No magnetic declination found in the raw file.")
     if pconfig.magnetic_declination:
         angle = pconfig.magnetic_declination
         if dataset.attrs["magnetic_declination"]:
-            angle = round((pconfig.magnetic_declination -
-                           dataset.attrs["magnetic_declination"]), 4)
-            l.log(
-                f"An additional correction of {angle} degree east was applied.")
+            angle = round((pconfig.magnetic_declination - dataset.attrs["magnetic_declination"]), 4)
+            l.log(f"An additional correction of {angle} degree east was applied.")
         _apply_magnetic_correction(dataset, angle)
         dataset.attrs["magnetic_declination"] = pconfig.magnetic_declination
-        l.log(
-            f"Absolute magnetic declination: {dataset.attrs['magnetic_declination']} degree east.")
+        l.log(f"Absolute magnetic declination: {dataset.attrs['magnetic_declination']} degree east.")
 
     if any(x is True for x in [pconfig.drop_percent_good, pconfig.drop_correlation, pconfig.drop_amplitude]):
         dataset = _drop_beam_data(dataset, pconfig)
@@ -464,8 +450,7 @@ def _process_adcp_data(pconfig: ProcessConfig):
         **P01_VEL_CODES[pconfig.platform_type],
         **P01_CODES,
     }
-    dataset.attrs["variables_gen_name"] = [
-        var for var in dataset.variables]  # For Odf outputs
+    dataset.attrs["variables_gen_name"] = [var for var in dataset.variables]  # For Odf outputs
 
     l.section("Variables attributes")
     dataset = format_variables_names_and_attributes(dataset)
@@ -517,8 +502,7 @@ def _process_adcp_data(pconfig: ProcessConfig):
     if pconfig.odf_output is True:
         if pconfig.odf_data is None:
             pconfig.odf_data = 'both'
-        odf_data = {'both': ['VEL', 'ANC'], 'vel': [
-            'VEL'], 'anc': ['ANC']}[pconfig.odf_data]
+        odf_data = {'both': ['VEL', 'ANC'], 'vel': ['VEL'], 'anc': ['ANC']}[pconfig.odf_data]
         for qualifier in odf_data:
             _ = make_odf(
                 dataset=dataset,
@@ -623,8 +607,7 @@ def _set_platform_metadata(dataset: xr.Dataset, pconfig: ProcessConfig):
     dataset :
         Dataset to which add the navigation data.
     """
-    metadata = {**pconfig.platform_metadata['platform'],
-                **pconfig.platform_metadata[pconfig.sensor_type]}
+    metadata = {**pconfig.platform_metadata['platform'], **pconfig.platform_metadata[pconfig.sensor_type]}
     metadata['sensor_comments'] = metadata['comments']
     if pconfig.force_platform_metadata:
         for key, value in metadata.items():
@@ -708,16 +691,14 @@ def _regrid_dataset(dataset: xr.Dataset, pconfig: ProcessConfig) -> xr.Dataset:
     # Pre-process flags
     for var_ in 'uvw':
         _flag_name = dataset[var_].attrs['ancillary_variables']
-        dataset[_flag_name].values = _prepare_flags_for_regrid(
-            dataset[_flag_name].data)
+        dataset[_flag_name].values = _prepare_flags_for_regrid(dataset[_flag_name].data)
 
     # Make new quality flags if grid_method is `bin`. Must happen before averaging.
     if pconfig.grid_method == 'bin':
         _new_flags = dict()
         for var_ in 'uvw':
             _flag_name = dataset[var_].attrs['ancillary_variables']
-            _new_flags[_flag_name] = _new_flags_bin_regrid(
-                dataset[_flag_name], _new_depths)
+            _new_flags[_flag_name] = _new_flags_bin_regrid(dataset[_flag_name], _new_depths)
         new_flags = xr.Dataset(_new_flags)
 
     # Apply quality control
@@ -972,10 +953,8 @@ def _default_platform_metadata() -> dict:
     platform_metadata = {'platform': _add_platform(), 'adcp_id': 'ADCP_01'}
     platform_metadata['platform']["platform_type"] = DEFAULT_PLATFORM_TYPE
     platform_metadata['sensors'] = platform_metadata['platform'].pop('sensors')
-    platform_metadata['adcp'] = platform_metadata['sensors'].pop(
-        '__enter_a_sensor_ID_here')
-    platform_metadata['buoy_specs'] = platform_metadata['platform'].pop(
-        'buoy_specs')
+    platform_metadata['adcp'] = platform_metadata['sensors'].pop('__enter_a_sensor_ID_here')
+    platform_metadata['buoy_specs'] = platform_metadata['platform'].pop('buoy_specs')
 
     return platform_metadata
 
@@ -992,21 +971,16 @@ def _load_platform(platform_file: str, platform_id: str, sensor_id: str) -> tp.D
     if platform_id in json_dict:
         platform_metadata['platform'].update(json_dict[platform_id])
         if 'buoy_specs' in platform_metadata['platform']:
-            platform_metadata['buoy_specs'].update(
-                platform_metadata['platform'].pop('buoy_specs'))
+            platform_metadata['buoy_specs'].update(platform_metadata['platform'].pop('buoy_specs'))
         if 'sensors' in platform_metadata['platform']:
-            platform_metadata['sensors'].update(
-                platform_metadata['platform'].pop('sensors'))
+            platform_metadata['sensors'].update(platform_metadata['platform'].pop('sensors'))
             if sensor_id in platform_metadata["sensors"]:
                 platform_metadata['adcp_id'] = sensor_id
-                platform_metadata['adcp'].update(
-                    platform_metadata["sensors"].pop(sensor_id))
+                platform_metadata['adcp'].update(platform_metadata["sensors"].pop(sensor_id))
             else:
-                l.warning(
-                    f"{sensor_id} not found in the {platform_id}['sensor'] section of the platform file.")
+                l.warning(f"{sensor_id} not found in the {platform_id}['sensor'] section of the platform file.")
         else:
-            l.warning(
-                f'sensors section missing in the {platform_id} section of the platform file.')
+            l.warning(f'sensors section missing in the {platform_id} section of the platform file.')
     else:
         l.warning(f"{platform_id} not found in platform file.")
     return platform_metadata

--- a/magtogoek/adcp/process.py
+++ b/magtogoek/adcp/process.py
@@ -238,6 +238,7 @@ class ProcessConfig:
     platform_metadata: dict = None
 
     drop_empty_attrs: bool = False
+    showfig: bool = True
     netcdf_path: str = None
     odf_path: str = None
     log_path: str = None
@@ -291,7 +292,9 @@ class ProcessConfig:
                 l.warning(f"platform_type set to `{DEFAULT_PLATFORM_TYPE}` for platform_type.")
 
 
-def process_adcp(config: dict, drop_empty_attrs: bool = False):
+def process_adcp(config: dict,
+                 drop_empty_attrs: bool = False,
+                 showfig: bool = True):
     """Process adcp data with parameters from a config file.
 
     Parameters
@@ -301,12 +304,15 @@ def process_adcp(config: dict, drop_empty_attrs: bool = False):
     drop_empty_attrs :
         If true, all netcdf empty ('') global attributes will be drop from
         the output.
+    showfig :
+        If true, display figures to the screen.
 
     The actual data processing is carried out by _process_adcp_data.
     """
 
     pconfig = ProcessConfig(config)
     pconfig.drop_empty_attrs = drop_empty_attrs
+    pconfig.showfig = showfig
 
     if pconfig.merge_output_files:
         _process_adcp_data(pconfig)
@@ -457,7 +463,8 @@ def _process_adcp_data(pconfig: ProcessConfig):
         make_adcp_figure(dataset,
                          flag_thres=2,
                          path=pconfig.figures_path,
-                         save=pconfig.figures_output)
+                         save=pconfig.figures_output,
+                         show=pconfig.showfig)
 
     dataset["time"].assign_attrs(TIME_ATTRS)
 

--- a/magtogoek/adcp/process.py
+++ b/magtogoek/adcp/process.py
@@ -231,7 +231,7 @@ class ProcessConfig:
     drop_percent_good: bool = None
     drop_correlation: bool = None
     drop_amplitude: bool = None
-    make_figures: bool = None
+    make_figures: tp.Union[str,bool] = None
     make_log: bool = None
     odf_data: str = None
     metadata: dict = None
@@ -241,7 +241,7 @@ class ProcessConfig:
     odf_path: str = None
     log_path: str = None
     figures_path: str = None
-    figures_output: tp.Union[str, bool] = None
+    figures_output: bool = None
 
     grid_depth: str = None
     grid_method: str = None
@@ -1050,14 +1050,16 @@ def _odf_output_handler(pconfig: ProcessConfig, default_path: Path, default_file
 
 def _figure_output_handler(pconfig: ProcessConfig, default_path: Path, default_filename: Path):
     if isinstance(pconfig.make_figures, bool):
-        if pconfig.figures_output is True:
-            pconfig.figures_path = str(default_path.joinpath(default_filename))
+        if pconfig.make_figures is True:
+            pconfig.figures_output = True
+            if pconfig.headless is True:
+                pconfig.figures_path = str(default_path.joinpath(default_filename))
     elif isinstance(pconfig.make_figures, str):
         _figures_output = Path(pconfig.make_figures)
         if Path(_figures_output.name) == _figures_output:
             _figures_path = default_path.joinpath(_figures_output).resolve()
         elif _figures_output.is_dir():
-            _figures_path = _figures_output
+            _figures_path = _figures_output.joinpath(default_filename)
         elif _figures_output.parent.is_dir():
             _figures_path = _figures_output
         else:

--- a/magtogoek/adcp/process.py
+++ b/magtogoek/adcp/process.py
@@ -996,6 +996,16 @@ def _outputs_path_handler(pconfig: ProcessConfig):
     if not pconfig.odf_output and not pconfig.netcdf_output:
         pconfig.netcdf_output = True
 
+    default_path, default_filename = _netcdf_output_handler(pconfig, default_path, default_filename)
+
+    default_path, default_filename = _odf_output_handler(pconfig, default_path, default_filename)
+
+    _figure_output_handler(pconfig, default_path, default_filename)
+
+    pconfig.log_path = str(default_path.joinpath(default_filename))
+
+
+def _netcdf_output_handler(pconfig: ProcessConfig, default_path: Path, default_filename: Path) -> tp.Tuple[Path, Path]:
     if isinstance(pconfig.netcdf_output, bool):
         if pconfig.netcdf_output is True:
             pconfig.netcdf_path = str(default_path.joinpath(default_filename))
@@ -1014,6 +1024,10 @@ def _outputs_path_handler(pconfig: ProcessConfig):
         pconfig.netcdf_path = str(netcdf_path)
         pconfig.netcdf_output = True
 
+    return default_path, default_filename
+
+
+def _odf_output_handler(pconfig: ProcessConfig, default_path: Path, default_filename: Path) -> tp.Tuple[Path, Path]:
     if isinstance(pconfig.odf_output, bool):
         if pconfig.odf_output is True:
             pconfig.odf_path = str(default_path)
@@ -1035,6 +1049,10 @@ def _outputs_path_handler(pconfig: ProcessConfig):
             default_path = _odf_path.parent
             default_filename = _odf_path.stem
 
+    return default_path, default_filename
+
+
+def _figure_output_handler(pconfig: ProcessConfig, default_path: Path, default_filename: Path):
     if isinstance(pconfig.make_figures, bool):
         pconfig.figures_output = False
         pconfig.figures_path = str(default_path.joinpath(default_filename))
@@ -1052,4 +1070,5 @@ def _outputs_path_handler(pconfig: ProcessConfig):
         pconfig.figures_path = str(_figures_path)
         pconfig.figures_output = True
 
-    pconfig.log_path = str(default_path.joinpath(default_filename))
+
+

--- a/magtogoek/app.py
+++ b/magtogoek/app.py
@@ -54,8 +54,7 @@ TERMINAL_WIDTH = 80
 def _print_info(ctx, callback, info_called):
     """Show command information"""
     if info_called is True:
-        subp_run(["printf", r"\e[8;40;" +
-                  str(TERMINAL_WIDTH + 1) + "t"], check=True)
+        subp_run(["printf", r"\e[8;40;" + str(TERMINAL_WIDTH + 1) + "t"], check=True)
         click.clear()
         _print_logo(logo_path=LOGO_PATH, group=ctx.info_name)
         click.secho("\nDescriptions:", fg="red")
@@ -74,8 +73,7 @@ def _print_info(ctx, callback, info_called):
 
 
 common_options = [
-    click.option("--info", is_flag=True, callback=_print_info,
-                 help="Show command information"),
+    click.option("--info", is_flag=True, callback=_print_info, help="Show command information"),
     click.version_option(VERSION)
 ]
 
@@ -113,8 +111,7 @@ def process(info, config_file: str, **options):
         cli_options['mk_fig'] = options['mk_fig']
 
     try:
-        configuration, sensor_type = load_configfile(
-            config_file, cli_options=cli_options)
+        configuration, sensor_type = load_configfile(config_file, cli_options=cli_options)
     except (ParsingError, UnicodeDecodeError):
         print("Failed to open the given configfile.\n mtgk process aborted.")
         sys.exit()
@@ -170,8 +167,7 @@ def config_platform(ctx, info, filename):
 
     filename = is_valid_filename(filename, ext=".json")
     make_platform_template(filename)
-    click.echo(click.style(
-        f"Platform file created for -> {filename}", bold=True))
+    click.echo(click.style(f"Platform file created for -> {filename}", bold=True))
 
 
 @config.command("adcp")
@@ -192,13 +188,10 @@ def config_adcp(
     _print_passed_options(options)
     config_name = is_valid_filename(config_name, ext=".ini")
     options['sensor_type'] = 'adcp'
-    options.update({k: v for k, v in zip(
-        ("platform_file", "platform_id", "sensor_id"), options.pop('platform'))})
+    options.update({k: v for k, v in zip(("platform_file", "platform_id", "sensor_id"), options.pop('platform'))})
 
-    write_configfile(filename=config_name,
-                     sensor_type="adcp", cli_options=options)
-    click.secho(
-        f"Config file created for adcp processing -> {config_name}", bold=True)
+    write_configfile(filename=config_name, sensor_type="adcp", cli_options=options)
+    click.secho(f"Config file created for adcp processing -> {config_name}", bold=True)
 
 
 # --------------------------- #
@@ -228,11 +221,9 @@ def quick_adcp(ctx, info, input_files: tuple, sonar: str, yearbase: int, **optio
     # TODO TEST. So far not crashing
     from magtogoek.config_handler import cli_options_to_config
     from magtogoek.adcp.process import process_adcp
-    options.update({"input_files": input_files,
-                    "sensor_type": "adcp", "yearbase": yearbase, "sonar": sonar})
+    options.update({"input_files": input_files, "sensor_type": "adcp", "yearbase": yearbase, "sonar": sonar})
     _print_passed_options(options)
-    configuration = cli_options_to_config(
-        'adcp', options, cwd=str(Path().cwd()))
+    configuration = cli_options_to_config('adcp', options, cwd=str(Path().cwd()))
 
     process_adcp(configuration,
                  drop_empty_attrs=True,
@@ -320,8 +311,7 @@ def plot_adcp(ctx, info, input_file, **options):
     import xarray as xr
     from magtogoek.adcp.adcp_plots import make_adcp_figure
     dataset = xr.open_dataset(input_file)
-    make_adcp_figure(
-        dataset, flag_thres=options['flag_thres'], vel_only=options["vel_only"])
+    make_adcp_figure(dataset, flag_thres=options['flag_thres'], vel_only=options["vel_only"])
 
 
 # ------------------------ #
@@ -361,14 +351,9 @@ def _print_logo(logo_path: str = "files/logo.json", group: str = ""):
     except FileNotFoundError:
         click.echo(click.style("WARNING: logo.json not found", fg="yellow"))
     except KeyError:
-        click.echo(click.style(
-            "WARNING: key in logo.json not found", fg="yellow"))
+        click.echo(click.style("WARNING: key in logo.json not found", fg="yellow"))
 
-    click.echo(
-        click.style(
-            f"version: {VERSION}" + f" {group} ".rjust(67, " "), fg="green", bold=True,
-        )
-    )
+    click.echo(click.style(f"version: {VERSION}" + f" {group} ".rjust(67, " "), fg="green", bold=True,))
     click.echo(click.style("=" * TERMINAL_WIDTH, fg="white", bold=True))
 
 
@@ -376,12 +361,9 @@ def _print_arguments(group, parent):
     """print group(command) command(arguments)"""
     _parent = parent.info_name if parent else ""
     messages = {"mtgk": '\n'.join(["  config".ljust(20, " ") + "Command to make configuration files",
-                                   "  process".ljust(
-                                       20, " ") + "Command to process data with configuration files",
-                                   "  quick".ljust(
-                                       20, " ") + "Command to quickly process data files",
-                                   "  check".ljust(
-                                       20, " ") + "Command to check the information on some file type",
+                                   "  process".ljust(20, " ") + "Command to process data with configuration files",
+                                   "  quick".ljust(20, " ") + "Command to quickly process data files",
+                                   "  check".ljust(20, " ") + "Command to check the information on some file type",
                                    "  compute".ljust(20, " ") + "Command to compute certain quantities"]),
                 "config":
                     '\n'.join(["  adcp".ljust(20, " ") + "Config file for adcp data. ",
@@ -399,11 +381,11 @@ def _print_arguments(group, parent):
                         "  [file_name]".ljust(20, " ")
                         + "Filename (path/to/file, or expression) of the GPS files."
 
-    ),
-        "check": "  rti".ljust(20, " ") + "Print information on the rti .ens files. ",
+                ),
+                "check": "  rti".ljust(20, " ") + "Print information on the rti .ens files. ",
 
-        "adcp": "  [config_name]".ljust(20, " ")
-        + "Filename (path/to/file) for the new configuration file.",
+                "adcp": "  [config_name]".ljust(20, " ")
+                        + "Filename (path/to/file) for the new configuration file.",
                 "platform": "  [filename]".ljust(20, " ")
                             + "Filename (path/to/file) for the new platform file.",
     }
@@ -425,46 +407,46 @@ def _print_description(group):
             " processing configuration for different types of sensor (adcp, ctd, etc). Once"
             " created the configuration file   can be filled in any text editor or via"
             " optional arguments. Platform files are used to store platform metadata."
-    ),
+        ),
         "quick": "Quick way to process files.",
         "process": (
             "Command to execute the processing orders from a configuration file. If"
             " relative path where used in the configuration file, they are relative to directory"
             " where the command is called and not where the configuration file is located."
-    ),
+        ),
         "check": (
             "Print some raw files information. Only available for adcp RTI .ENS files."
-    ),
+        ),
         "adcp": (
-        "\n"
-        "        sonar\n"
-        "        -----\n"
-        "           os : OceanSurveyor (RDI)\n"
-        "           wh : WorkHorse (RDI)\n"
-        "           sv : SentinelV (RDI)\n"
-        "           sw : SeaWatch (RTI)\n"
-        "           sw_pd0 : SeaWatch (RTI in RDI pd0 file format)\n"
-        "\n"
-        "        quality control\n"
-        "        ---------------\n"
-        "           - velocity, amplitude, correlation, percentgood, roll, pitch, \n"
-        "             side_lobe.\n"
-        "           - Temperatures outside [-2, 32] Celsius. \n"
-        "           - Pressures outside [0, 180] dbar.\n"
-        "\n"
-        "        plots\n"
-        "        -----\n"
-        "           - 2D velocity fields (u,v), time-series,\n"
-        "           - Polar Histogram of the Velocities amplitude and direction,\n"
-        "           - Pearson Correlation of velocity for consecutive bins,\n"
-    ),
+                "\n"
+                "        sonar\n"
+                "        -----\n"
+                "           os : OceanSurveyor (RDI)\n"
+                "           wh : WorkHorse (RDI)\n"
+                "           sv : SentinelV (RDI)\n"
+                "           sw : SeaWatch (RTI)\n"
+                "           sw_pd0 : SeaWatch (RTI in RDI pd0 file format)\n"
+                "\n"
+                "        quality control\n"
+                "        ---------------\n"
+                "           - velocity, amplitude, correlation, percentgood, roll, pitch, \n"
+                "             side_lobe.\n"
+                "           - Temperatures outside [-2, 32] Celsius. \n"
+                "           - Pressures outside [0, 180] dbar.\n"
+                "\n"
+                "        plots\n"
+                "        -----\n"
+                "           - 2D velocity fields (u,v), time-series,\n"
+                "           - Polar Histogram of the Velocities amplitude and direction,\n"
+                "           - Pearson Correlation of velocity for consecutive bins,\n"
+        ),
         "nav": (
             " Compute u_ship (eastward velocity), v_ship (northward velocity) and the bearing"
             " of the input gps data. The GPS input files can be nmea text file, gpx XML files or"
             " a netcdf files with `lon`, `lat` variables and `time` coordinates. Using the command"
             " `-w`, an averaging window can be use to smooth the computed navigation data."
             " A matplotlib plot is made after each computation."
-    ),
+        ),
         "platform": "Creates an empty platform.json file",
         "odf2nc": "Converts odf files to netcdf",
     }
@@ -472,8 +454,7 @@ def _print_description(group):
         if "\n" in messages[group]:
             click.echo(messages[group])
         else:
-            click.echo(click.wrap_text(
-                messages[group], width=TERMINAL_WIDTH, initial_indent=''))
+            click.echo(click.wrap_text(messages[group], width=TERMINAL_WIDTH, initial_indent=''))
 
 
 def _print_usage(group, parent):
@@ -494,8 +475,7 @@ def _print_usage(group, parent):
         if _parent == "config":
             click.echo("  mtgk config adcp [CONFIG_NAME] [OPTIONS]")
         if _parent == "quick":
-            click.echo(
-                "  mtgk quick adcp [INPUT_FILES] [SONAR] [YEARBASE] [OPTIONS]")
+            click.echo("  mtgk quick adcp [INPUT_FILES] [SONAR] [YEARBASE] [OPTIONS]")
     if group == "check":
         click.echo("  mtgk check [rti,] [INPUT_FILES] ")
     if group == "rti":

--- a/magtogoek/app.py
+++ b/magtogoek/app.py
@@ -210,6 +210,10 @@ def config_adcp(
               help="""year when the adcp sampling started. ex: `1970`""", required=True)
 @click.option("-T", "--platform_type", type=click.Choice(["buoy", "mooring", "ship"]),
               help="Used for Proper BODC variables names", default="buoy")
+@click.option("--show-fig", "showfig",
+              type=bool,
+              help="""Display figures to inspect the data.""",
+              default=True)
 @click.pass_context
 def quick_adcp(ctx, info, input_files: tuple, sonar: str, yearbase: int, **options: dict):
     """Command to make an quickly process adcp files. The [OPTIONS] can be added
@@ -221,7 +225,7 @@ def quick_adcp(ctx, info, input_files: tuple, sonar: str, yearbase: int, **optio
     _print_passed_options(options)
     configuration = cli_options_to_config('adcp', options, cwd=str(Path().cwd()))
 
-    process_adcp(configuration, drop_empty_attrs=True)
+    process_adcp(configuration, drop_empty_attrs=True, showfig=configuration.showfig)
 
 
 # --------------------------- #

--- a/magtogoek/app.py
+++ b/magtogoek/app.py
@@ -217,7 +217,7 @@ def config_adcp(
               help="""year when the adcp sampling started. ex: `1970`""", required=True)
 @click.option("-T", "--platform_type", type=click.Choice(["buoy", "mooring", "ship"]),
               help="Used for Proper BODC variables names", default="buoy")
-@click.option("--show-fig", "showfig",
+@click.option("--show-fig/--hide-fig", "showfig",
               type=bool,
               help="""Display figures to inspect the data.""",
               default=True)
@@ -234,8 +234,9 @@ def quick_adcp(ctx, info, input_files: tuple, sonar: str, yearbase: int, **optio
     configuration = cli_options_to_config(
         'adcp', options, cwd=str(Path().cwd()))
 
-    process_adcp(configuration, drop_empty_attrs=True,
-                 showfig=configuration.showfig)
+    process_adcp(configuration,
+                 drop_empty_attrs=True,
+                 showfig=options['showfig'])
 
 
 # --------------------------- #

--- a/magtogoek/app.py
+++ b/magtogoek/app.py
@@ -97,6 +97,9 @@ def magtogoek(info):
               type=bool,
               help="""Make figures to inspect the data. Use to overwrite the value in the config_file""",
               default=None)
+@click.option("--headless",
+              is_flag=True,
+              help="""Using remotely with no display capability""")
 def process(info, config_file: str, **options):
     """Process data by reading configfile"""
     # NOTE This could be update as a group with sensor specific command.
@@ -119,7 +122,7 @@ def process(info, config_file: str, **options):
     if sensor_type == "adcp":
         from magtogoek.adcp.process import process_adcp
 
-        process_adcp(configuration)
+        process_adcp(configuration, headless=options['headless'])
 
 
 # --------------------------- #
@@ -210,10 +213,9 @@ def config_adcp(
               help="""year when the adcp sampling started. ex: `1970`""", required=True)
 @click.option("-T", "--platform_type", type=click.Choice(["buoy", "mooring", "ship"]),
               help="Used for Proper BODC variables names", default="buoy")
-@click.option("--show-fig/--hide-fig", "showfig",
-              type=bool,
-              help="""Display figures to inspect the data.""",
-              default=True)
+@click.option("--headless",
+              is_flag=True,
+              help="""Using remotely with no display capability""")
 @click.pass_context
 def quick_adcp(ctx, info, input_files: tuple, sonar: str, yearbase: int, **options: dict):
     """Command to make an quickly process adcp files. The [OPTIONS] can be added
@@ -227,7 +229,7 @@ def quick_adcp(ctx, info, input_files: tuple, sonar: str, yearbase: int, **optio
 
     process_adcp(configuration,
                  drop_empty_attrs=True,
-                 showfig=options['showfig'])
+                 headless=options['headless'])
 
 
 # --------------------------- #

--- a/magtogoek/app.py
+++ b/magtogoek/app.py
@@ -353,7 +353,11 @@ def _print_logo(logo_path: str = "files/logo.json", group: str = ""):
     except KeyError:
         click.echo(click.style("WARNING: key in logo.json not found", fg="yellow"))
 
-    click.echo(click.style(f"version: {VERSION}" + f" {group} ".rjust(67, " "), fg="green", bold=True,))
+    click.echo(
+        click.style(
+            f"version: {VERSION}" + f" {group} ".rjust(67, " "), fg="green", bold=True,
+        )
+    )
     click.echo(click.style("=" * TERMINAL_WIDTH, fg="white", bold=True))
 
 
@@ -449,7 +453,7 @@ def _print_description(group):
         ),
         "platform": "Creates an empty platform.json file",
         "odf2nc": "Converts odf files to netcdf",
-    }
+        }
     if group in messages:
         if "\n" in messages[group]:
             click.echo(messages[group])

--- a/magtogoek/app.py
+++ b/magtogoek/app.py
@@ -307,13 +307,16 @@ def odf2nc(ctx, info, input_files, output_name, **options):
 @click.option("-t", "--flag-thres", help="""Set threshold value for flagging""", default=2, show_default=True)
 @click.option("-v", "--vel-only", help="""Only plots 2D velocity fields and polar histogram.""", is_flag=True,
               default=False)
+@click.option("-s", "--save_fig", help="""Path to save figures to.""", type=click.Path(exists=True), default=None)
+@click.option("--headless", help="""If True, figures en displayed""", is_flag=True, default=False)
 @click.pass_context
 def plot_adcp(ctx, info, input_file, **options):
     """Command to compute u_ship, v_ship, bearing from gsp data."""
     import xarray as xr
     from magtogoek.adcp.adcp_plots import make_adcp_figure
     dataset = xr.open_dataset(input_file)
-    make_adcp_figure(dataset, flag_thres=options['flag_thres'], vel_only=options["vel_only"])
+    make_adcp_figure(dataset, flag_thres=options['flag_thres'], vel_only=options["vel_only"],
+                     save_path=options['save_fig'], show_fig=~options['headless'])
 
 
 # ------------------------ #

--- a/magtogoek/app.py
+++ b/magtogoek/app.py
@@ -54,7 +54,8 @@ TERMINAL_WIDTH = 80
 def _print_info(ctx, callback, info_called):
     """Show command information"""
     if info_called is True:
-        subp_run(["printf", r"\e[8;40;" + str(TERMINAL_WIDTH + 1) + "t"], check=True)
+        subp_run(["printf", r"\e[8;40;" +
+                  str(TERMINAL_WIDTH + 1) + "t"], check=True)
         click.clear()
         _print_logo(logo_path=LOGO_PATH, group=ctx.info_name)
         click.secho("\nDescriptions:", fg="red")
@@ -73,7 +74,8 @@ def _print_info(ctx, callback, info_called):
 
 
 common_options = [
-    click.option("--info", is_flag=True, callback=_print_info, help="Show command information"),
+    click.option("--info", is_flag=True, callback=_print_info,
+                 help="Show command information"),
     click.version_option(VERSION)
 ]
 
@@ -111,7 +113,8 @@ def process(info, config_file: str, **options):
         cli_options['mk_fig'] = options['mk_fig']
 
     try:
-        configuration, sensor_type = load_configfile(config_file, cli_options=cli_options)
+        configuration, sensor_type = load_configfile(
+            config_file, cli_options=cli_options)
     except (ParsingError, UnicodeDecodeError):
         print("Failed to open the given configfile.\n mtgk process aborted.")
         sys.exit()
@@ -167,7 +170,8 @@ def config_platform(ctx, info, filename):
 
     filename = is_valid_filename(filename, ext=".json")
     make_platform_template(filename)
-    click.echo(click.style(f"Platform file created for -> {filename}", bold=True))
+    click.echo(click.style(
+        f"Platform file created for -> {filename}", bold=True))
 
 
 @config.command("adcp")
@@ -188,10 +192,13 @@ def config_adcp(
     _print_passed_options(options)
     config_name = is_valid_filename(config_name, ext=".ini")
     options['sensor_type'] = 'adcp'
-    options.update({k: v for k, v in zip(("platform_file", "platform_id", "sensor_id"), options.pop('platform'))})
+    options.update({k: v for k, v in zip(
+        ("platform_file", "platform_id", "sensor_id"), options.pop('platform'))})
 
-    write_configfile(filename=config_name, sensor_type="adcp", cli_options=options)
-    click.secho(f"Config file created for adcp processing -> {config_name}", bold=True)
+    write_configfile(filename=config_name,
+                     sensor_type="adcp", cli_options=options)
+    click.secho(
+        f"Config file created for adcp processing -> {config_name}", bold=True)
 
 
 # --------------------------- #
@@ -221,11 +228,14 @@ def quick_adcp(ctx, info, input_files: tuple, sonar: str, yearbase: int, **optio
     # TODO TEST. So far not crashing
     from magtogoek.config_handler import cli_options_to_config
     from magtogoek.adcp.process import process_adcp
-    options.update({"input_files": input_files, "sensor_type": "adcp", "yearbase": yearbase, "sonar": sonar})
+    options.update({"input_files": input_files,
+                    "sensor_type": "adcp", "yearbase": yearbase, "sonar": sonar})
     _print_passed_options(options)
-    configuration = cli_options_to_config('adcp', options, cwd=str(Path().cwd()))
+    configuration = cli_options_to_config(
+        'adcp', options, cwd=str(Path().cwd()))
 
-    process_adcp(configuration, drop_empty_attrs=True, showfig=configuration.showfig)
+    process_adcp(configuration, drop_empty_attrs=True,
+                 showfig=configuration.showfig)
 
 
 # --------------------------- #
@@ -309,7 +319,8 @@ def plot_adcp(ctx, info, input_file, **options):
     import xarray as xr
     from magtogoek.adcp.adcp_plots import make_adcp_figure
     dataset = xr.open_dataset(input_file)
-    make_adcp_figure(dataset, flag_thres=options['flag_thres'], vel_only=options["vel_only"])
+    make_adcp_figure(
+        dataset, flag_thres=options['flag_thres'], vel_only=options["vel_only"])
 
 
 # ------------------------ #
@@ -349,7 +360,8 @@ def _print_logo(logo_path: str = "files/logo.json", group: str = ""):
     except FileNotFoundError:
         click.echo(click.style("WARNING: logo.json not found", fg="yellow"))
     except KeyError:
-        click.echo(click.style("WARNING: key in logo.json not found", fg="yellow"))
+        click.echo(click.style(
+            "WARNING: key in logo.json not found", fg="yellow"))
 
     click.echo(
         click.style(
@@ -363,9 +375,12 @@ def _print_arguments(group, parent):
     """print group(command) command(arguments)"""
     _parent = parent.info_name if parent else ""
     messages = {"mtgk": '\n'.join(["  config".ljust(20, " ") + "Command to make configuration files",
-                                   "  process".ljust(20, " ") + "Command to process data with configuration files",
-                                   "  quick".ljust(20, " ") + "Command to quickly process data files",
-                                   "  check".ljust(20, " ") + "Command to check the information on some file type",
+                                   "  process".ljust(
+                                       20, " ") + "Command to process data with configuration files",
+                                   "  quick".ljust(
+                                       20, " ") + "Command to quickly process data files",
+                                   "  check".ljust(
+                                       20, " ") + "Command to check the information on some file type",
                                    "  compute".ljust(20, " ") + "Command to compute certain quantities"]),
                 "config":
                     '\n'.join(["  adcp".ljust(20, " ") + "Config file for adcp data. ",
@@ -383,14 +398,14 @@ def _print_arguments(group, parent):
                         "  [file_name]".ljust(20, " ")
                         + "Filename (path/to/file, or expression) of the GPS files."
 
-                ),
-                "check": "  rti".ljust(20, " ") + "Print information on the rti .ens files. ",
+    ),
+        "check": "  rti".ljust(20, " ") + "Print information on the rti .ens files. ",
 
-                "adcp": "  [config_name]".ljust(20, " ")
-                        + "Filename (path/to/file) for the new configuration file.",
+        "adcp": "  [config_name]".ljust(20, " ")
+        + "Filename (path/to/file) for the new configuration file.",
                 "platform": "  [filename]".ljust(20, " ")
                             + "Filename (path/to/file) for the new platform file.",
-                }
+    }
     if group in messages:
         click.secho(messages[group], fg="white")
 
@@ -409,46 +424,46 @@ def _print_description(group):
             " processing configuration for different types of sensor (adcp, ctd, etc). Once"
             " created the configuration file   can be filled in any text editor or via"
             " optional arguments. Platform files are used to store platform metadata."
-        ),
+    ),
         "quick": "Quick way to process files.",
         "process": (
             "Command to execute the processing orders from a configuration file. If"
             " relative path where used in the configuration file, they are relative to directory"
             " where the command is called and not where the configuration file is located."
-        ),
+    ),
         "check": (
             "Print some raw files information. Only available for adcp RTI .ENS files."
-        ),
+    ),
         "adcp": (
-                "\n"
-                "        sonar\n"
-                "        -----\n"
-                "           os : OceanSurveyor (RDI)\n"
-                "           wh : WorkHorse (RDI)\n"
-                "           sv : SentinelV (RDI)\n"
-                "           sw : SeaWatch (RTI)\n"
-                "           sw_pd0 : SeaWatch (RTI in RDI pd0 file format)\n"
-                "\n"
-                "        quality control\n"
-                "        ---------------\n"
-                "           - velocity, amplitude, correlation, percentgood, roll, pitch, \n"
-                "             side_lobe.\n"
-                "           - Temperatures outside [-2, 32] Celsius. \n"
-                "           - Pressures outside [0, 180] dbar.\n"
-                "\n"
-                "        plots\n"
-                "        -----\n"
-                "           - 2D velocity fields (u,v), time-series,\n"
-                "           - Polar Histogram of the Velocities amplitude and direction,\n"
-                "           - Pearson Correlation of velocity for consecutive bins,\n"
-        ),
+        "\n"
+        "        sonar\n"
+        "        -----\n"
+        "           os : OceanSurveyor (RDI)\n"
+        "           wh : WorkHorse (RDI)\n"
+        "           sv : SentinelV (RDI)\n"
+        "           sw : SeaWatch (RTI)\n"
+        "           sw_pd0 : SeaWatch (RTI in RDI pd0 file format)\n"
+        "\n"
+        "        quality control\n"
+        "        ---------------\n"
+        "           - velocity, amplitude, correlation, percentgood, roll, pitch, \n"
+        "             side_lobe.\n"
+        "           - Temperatures outside [-2, 32] Celsius. \n"
+        "           - Pressures outside [0, 180] dbar.\n"
+        "\n"
+        "        plots\n"
+        "        -----\n"
+        "           - 2D velocity fields (u,v), time-series,\n"
+        "           - Polar Histogram of the Velocities amplitude and direction,\n"
+        "           - Pearson Correlation of velocity for consecutive bins,\n"
+    ),
         "nav": (
             " Compute u_ship (eastward velocity), v_ship (northward velocity) and the bearing"
             " of the input gps data. The GPS input files can be nmea text file, gpx XML files or"
             " a netcdf files with `lon`, `lat` variables and `time` coordinates. Using the command"
             " `-w`, an averaging window can be use to smooth the computed navigation data."
             " A matplotlib plot is made after each computation."
-        ),
+    ),
         "platform": "Creates an empty platform.json file",
         "odf2nc": "Converts odf files to netcdf",
     }
@@ -456,7 +471,8 @@ def _print_description(group):
         if "\n" in messages[group]:
             click.echo(messages[group])
         else:
-            click.echo(click.wrap_text(messages[group], width=TERMINAL_WIDTH, initial_indent=''))
+            click.echo(click.wrap_text(
+                messages[group], width=TERMINAL_WIDTH, initial_indent=''))
 
 
 def _print_usage(group, parent):
@@ -477,7 +493,8 @@ def _print_usage(group, parent):
         if _parent == "config":
             click.echo("  mtgk config adcp [CONFIG_NAME] [OPTIONS]")
         if _parent == "quick":
-            click.echo("  mtgk quick adcp [INPUT_FILES] [SONAR] [YEARBASE] [OPTIONS]")
+            click.echo(
+                "  mtgk quick adcp [INPUT_FILES] [SONAR] [YEARBASE] [OPTIONS]")
     if group == "check":
         click.echo("  mtgk check [rti,] [INPUT_FILES] ")
     if group == "rti":

--- a/magtogoek/config_handler.py
+++ b/magtogoek/config_handler.py
@@ -246,7 +246,7 @@ def get_config_taskparser(sensor_type: Optional[str] = None):
         tparser.add_option(section, "drop_correlation", dtypes=["bool"], default=True, null_value=False)
         tparser.add_option(section, "drop_amplitude", dtypes=["bool"], default=True, null_value=False)
         tparser.add_option(section, "odf_data", dtypes=["str"], default="both", choice=["vel", "anc", "both"], comments='One of [vel, anc, both,].')
-        tparser.add_option(section, "make_figures", dtypes=["bool"], default=True, null_value=False)
+        tparser.add_option(section, "make_figures", dtypes=["bool", "str"], default=True, null_value=False)
         tparser.add_option(section, "make_log", dtypes=["bool"], default=True, null_value=False)
 
     return tparser

--- a/magtogoek/config_handler.py
+++ b/magtogoek/config_handler.py
@@ -90,11 +90,9 @@ def write_configfile(filename: str, sensor_type: str, cli_options: Optional[dict
 
     cli_config = None
     if cli_options is not None:
-        cli_config = _format_cli_options_to_config_dict(
-            sensor_type, tparser, cli_options)
+        cli_config = _format_cli_options_to_config_dict(sensor_type, tparser, cli_options)
 
-    tparser.write_from_dict(
-        filename=filename, parser_dict=cli_config, add_missing=True, format_options=False)
+    tparser.write_from_dict(filename=filename, parser_dict=cli_config, add_missing=True, format_options=False)
 
 
 def load_configfile(filename: str, cli_options: Optional[dict] = None) -> ParserDict:
@@ -116,11 +114,9 @@ def load_configfile(filename: str, cli_options: Optional[dict] = None) -> Parser
 
     cli_config = None
     if cli_options is not None:
-        cli_config = _format_cli_options_to_config_dict(
-            sensor_type, tparser, cli_options)
+        cli_config = _format_cli_options_to_config_dict(sensor_type, tparser, cli_options)
 
-    config = tparser.load(filename, add_missing=True,
-                          new_values_dict=cli_config, format_options=True)
+    config = tparser.load(filename, add_missing=True, new_values_dict=cli_config, format_options=True)
 
     return config, sensor_type
 
@@ -138,11 +134,9 @@ def cli_options_to_config(sensor_type: str, cli_options: dict, cwd: Optional[str
     """
     tparser = get_config_taskparser(sensor_type)
     config = tparser.as_dict(with_default=True)
-    cli_config = _format_cli_options_to_config_dict(
-        sensor_type, tparser, cli_options)
+    cli_config = _format_cli_options_to_config_dict(sensor_type, tparser, cli_options)
 
-    tparser.format_parser_dict(
-        parser_dict=cli_config, add_missing=True, format_options=True, file_path=cwd)
+    tparser.format_parser_dict(parser_dict=cli_config, add_missing=True, format_options=True, file_path=cwd)
 
     return cli_config
 
@@ -156,40 +150,29 @@ def get_config_taskparser(sensor_type: Optional[str] = None):
     tparser = TaskParser()
 
     section = "HEADER"
-    tparser.add_option(section, "made_by", dtypes=[
-                       "str"], default=getpass.getuser())
-    tparser.add_option(section, "last_updated", dtypes=[
-                       "str"], default=datetime.now().strftime("%Y-%m-%d"))
-    tparser.add_option(section, "sensor_type", dtypes=[
-                       "str"], default=sensor_type, is_required=True, choice=["adcp"], comments='One of [adcp, ].')
-    tparser.add_option(section, "platform_type", dtypes=["str"], choice=[
-                       "buoy", "mooring", "ship"], comments='One of [buoy, mooring, ship, ].')
+    tparser.add_option(section, "made_by", dtypes=["str"], default=getpass.getuser())
+    tparser.add_option(section, "last_updated", dtypes=["str"], default=datetime.now().strftime("%Y-%m-%d"))
+    tparser.add_option(section, "sensor_type", dtypes=["str"], default=sensor_type, is_required=True, choice=["adcp"], comments='One of [adcp, ].')
+    tparser.add_option(section, "platform_type", dtypes=["str"], choice=["buoy", "mooring", "ship"], comments='One of [buoy, mooring, ship, ].')
 
     section = "INPUT"
-    tparser.add_option(section, "input_files", dtypes=[
-                       "str"], default="", nargs_min=1, is_file=True, is_required=True)
-    tparser.add_option(section, "platform_file", dtypes=[
-                       "str"], default=None, is_file=True)
+    tparser.add_option(section, "input_files", dtypes=["str"], default="", nargs_min=1, is_file=True, is_required=True)
+    tparser.add_option(section, "platform_file", dtypes=["str"], default=None, is_file=True)
     tparser.add_option(section, "platform_id", dtypes=["str"], default=None)
     tparser.add_option(section, "sensor_id", dtypes=["str"], default=None)
 
     section = "OUTPUT"
-    tparser.add_option(section, "netcdf_output", dtypes=[
-                       "str", "bool"], default="", is_path=True, null_value=False)
-    tparser.add_option(section, "odf_output", dtypes=[
-                       "str", "bool"], default="", is_path=True, null_value=False)
+    tparser.add_option(section, "netcdf_output", dtypes=["str", "bool"], default="", is_path=True, null_value=False)
+    tparser.add_option(section, "odf_output", dtypes=["str", "bool"], default="", is_path=True, null_value=False)
 
     section = "NETCDF_CF"
-    tparser.add_option(section, "Conventions", dtypes=[
-                       "str"], default="CF 1.8")
+    tparser.add_option(section, "Conventions", dtypes=["str"], default="CF 1.8")
     tparser.add_option(section, "title", dtypes=["str"], default="")
     tparser.add_option(section, "institution", dtypes=["str"], default="")
     tparser.add_option(section, "summary", dtypes=["str"], default="")
-    tparser.add_option(section, "references", dtypes=[
-                       "str"], default=REFERENCE)
+    tparser.add_option(section, "references", dtypes=["str"], default=REFERENCE)
     tparser.add_option(section, "comments", dtypes=["str"], default="")
-    tparser.add_option(section, "naming_authority", dtypes=[
-                       "str"], default="BODC, SDC, CF, MEDS")
+    tparser.add_option(section, "naming_authority", dtypes=["str"], default="BODC, SDC, CF, MEDS")
     tparser.add_option(section, "source", dtypes=["str"], default="")
 
     section = "PROJECT"
@@ -198,23 +181,16 @@ def get_config_taskparser(sensor_type: Optional[str] = None):
     tparser.add_option(section, "sea_code", dtypes=["str"], default="")
 
     section = "CRUISE"
-    tparser.add_option(section, "country_institute_code",
-                       dtypes=["str"], default="")
-    tparser.add_option(section, "cruise_number", dtypes=[
-                       "str"], default="", null_value="")
+    tparser.add_option(section, "country_institute_code", dtypes=["str"], default="")
+    tparser.add_option(section, "cruise_number", dtypes=["str"], default="", null_value="")
     tparser.add_option(section, "cruise_name", dtypes=["str"], default="")
-    tparser.add_option(section, "cruise_description",
-                       dtypes=["str"], default="")
+    tparser.add_option(section, "cruise_description", dtypes=["str"], default="")
     tparser.add_option(section, "organization", dtypes=["str"], default="")
     tparser.add_option(section, "chief_scientist", dtypes=["str"], default="")
-    tparser.add_option(section, "start_date", dtypes=[
-                       "str", "int"], default="", is_time_stamp=True)
-    tparser.add_option(section, "end_date", dtypes=[
-                       "str", "int"], default="", is_time_stamp=True)
-    tparser.add_option(section, "event_number", dtypes=[
-                       "str"], default="", null_value="")
-    tparser.add_option(section, "event_qualifier1", dtypes=[
-                       "str"], default="", null_value="")
+    tparser.add_option(section, "start_date", dtypes=["str", "int"], default="", is_time_stamp=True)
+    tparser.add_option(section, "end_date", dtypes=["str", "int"], default="", is_time_stamp=True)
+    tparser.add_option(section, "event_number", dtypes=["str"], default="", null_value="")
+    tparser.add_option(section, "event_qualifier1", dtypes=["str"], default="", null_value="")
     tparser.add_option(section, "event_comments", dtypes=["str"], default="")
 
     section = "GLOBAL_ATTRIBUTES"
@@ -225,90 +201,53 @@ def get_config_taskparser(sensor_type: Optional[str] = None):
     tparser.add_option(section, "creator_type", dtypes=["str"], default="")
     tparser.add_option(section, "publisher_name", dtypes=["str"], default="")
     tparser.add_option(section, "keywords", dtypes=["str"], default="")
-    tparser.add_option(section, "keywords_vocabulary",
-                       dtypes=["str"], default="")
-    tparser.add_option(section, "standard_name_vocabulary",
-                       dtypes=["str"], default="CF v.52")
+    tparser.add_option(section, "keywords_vocabulary", dtypes=["str"], default="")
+    tparser.add_option(section, "standard_name_vocabulary", dtypes=["str"], default="CF v.52")
     tparser.add_option(section, "acknowledgment", dtypes=["str"], default="")
 
     if sensor_type == 'adcp':
         section = "ADCP_PROCESSING"
-        tparser.add_option(section, "yearbase", dtypes=[
-                           "int"], default="", is_required=True)
-        tparser.add_option(section, "adcp_orientation", dtypes=[
-                           "str"], default="down", choice=["up", "down"], comments='up or down')
-        tparser.add_option(section, "sonar", dtypes=["str"], choice=["wh", "sv", "os", "sw", "sw_pd0"], comments='[wh, sv, os, sw, sw_pd0, ]',
-                           is_required=True)
-        tparser.add_option(section, "navigation_file", dtypes=[
-                           "str"], default="", is_file=True)
-        tparser.add_option(section, "leading_trim", dtypes=[
-                           "int", "str"], default="", is_time_stamp=True)
-        tparser.add_option(section, "trailing_trim", dtypes=[
-                           "int", "str"], default="", is_time_stamp=True)
-        tparser.add_option(section, "sensor_depth",
-                           dtypes=["float"], default="")
-        tparser.add_option(section, "depth_range", dtypes=[
-                           "float"], nargs_min=0, nargs_max=2)
-        tparser.add_option(section, "bad_pressure", dtypes=[
-                           "bool"], default=False, null_value=False)
-        tparser.add_option(section, "magnetic_declination",
-                           dtypes=["float"], default="")
-        tparser.add_option(section, "keep_bt", dtypes=[
-                           "bool"], default=True, null_value=False)
-        tparser.add_option(section, "start_time", dtypes=[
-                           "str"], default="", is_time_stamp=True)
+        tparser.add_option(section, "yearbase", dtypes=["int"], default="", is_required=True)
+        tparser.add_option(section, "adcp_orientation", dtypes=["str"], default="down", choice=["up", "down"], comments='up or down')
+        tparser.add_option(section, "sonar", dtypes=["str"], choice=["wh", "sv", "os", "sw", "sw_pd0"], comments='[wh, sv, os, sw, sw_pd0, ]', is_required=True)
+        tparser.add_option(section, "navigation_file", dtypes=["str"], default="", is_file=True)
+        tparser.add_option(section, "leading_trim", dtypes=["int", "str"], default="", is_time_stamp=True)
+        tparser.add_option(section, "trailing_trim", dtypes=["int", "str"], default="", is_time_stamp=True)
+        tparser.add_option(section, "sensor_depth", dtypes=["float"], default="")
+        tparser.add_option(section, "depth_range", dtypes=["float"], nargs_min=0, nargs_max=2)
+        tparser.add_option(section, "bad_pressure", dtypes=["bool"], default=False, null_value=False)
+        tparser.add_option(section, "magnetic_declination", dtypes=["float"], default="")
+        tparser.add_option(section, "keep_bt", dtypes=["bool"], default=True, null_value=False)
+        tparser.add_option(section, "start_time", dtypes=["str"], default="", is_time_stamp=True)
         tparser.add_option(section, "time_step", dtypes=["float"], default="")
-        tparser.add_option(section, "grid_depth", dtypes=[
-                           "str"], default="", comments='Path to column grid file (m).', is_path=True, nargs_min=1)
-        tparser.add_option(section, "grid_method", dtypes=[
-                           "str"], default="interp", choice=["interp", "bin"], comments='[interp, bin].')
+        tparser.add_option(section, "grid_depth", dtypes=["str"], default="", comments='Path to column grid file (m).', is_path=True, nargs_min=1)
+        tparser.add_option(section, "grid_method", dtypes=["str"], default="interp", choice=["interp", "bin"], comments='[interp, bin].')
 
         section = "ADCP_QUALITY_CONTROL"
-        tparser.add_option(section, "quality_control", dtypes=[
-                           "bool"], default=True, null_value=False)
-        tparser.add_option(section, "amplitude_threshold", dtypes=[
-                           "int"], default=0, value_min=0, value_max=255, comments='Value between 0 and 255.')
-        tparser.add_option(section, "percentgood_threshold", dtypes=[
-                           "int"], default=64, value_min=0, value_max=100, comments='Value between 0 and 100.')
-        tparser.add_option(section, "correlation_threshold", dtypes=[
-                           "int"], default=90, value_min=0, value_max=255, comments='Value between 0 and 255.')
-        tparser.add_option(section, "horizontal_velocity_threshold", dtypes=[
-                           "float"], default=5)
-        tparser.add_option(section, "vertical_velocity_threshold", dtypes=[
-                           "float"], default=5)
-        tparser.add_option(section, "error_velocity_threshold",
-                           dtypes=["float"], default=5)
-        tparser.add_option(section, "sidelobes_correction", dtypes=[
-                           "bool"], default=True, null_value=False)
+        tparser.add_option(section, "quality_control", dtypes=["bool"], default=True, null_value=False)
+        tparser.add_option(section, "amplitude_threshold", dtypes=["int"], default=0, value_min=0, value_max=255, comments='Value between 0 and 255.')
+        tparser.add_option(section, "percentgood_threshold", dtypes=["int"], default=64, value_min=0, value_max=100, comments='Value between 0 and 100.')
+        tparser.add_option(section, "correlation_threshold", dtypes=["int"], default=90, value_min=0, value_max=255, comments='Value between 0 and 255.')
+        tparser.add_option(section, "horizontal_velocity_threshold", dtypes=["float"], default=5)
+        tparser.add_option(section, "vertical_velocity_threshold", dtypes=["float"], default=5)
+        tparser.add_option(section, "error_velocity_threshold", dtypes=["float"], default=5)
+        tparser.add_option(section, "sidelobes_correction", dtypes=["bool"], default=True, null_value=False)
         tparser.add_option(section, "bottom_depth", dtypes=["float"])
-        tparser.add_option(section, "pitch_threshold", dtypes=[
-                           "int"], default=20, value_min=0, value_max=180, comments='Value between 0 and 180.')
-        tparser.add_option(section, "roll_threshold", dtypes=[
-                           "int"], default=20, value_min=0, value_max=180, comments='Value between 0 and 180.')
-        tparser.add_option(section, "motion_correction_mode", dtypes=[
-                           "str"], default="bt", choice=["bt", "nav", "off"], comments='[bt, nav, off, ].')
+        tparser.add_option(section, "pitch_threshold", dtypes=["int"], default=20, value_min=0, value_max=180, comments='Value between 0 and 180.')
+        tparser.add_option(section, "roll_threshold", dtypes=["int"], default=20, value_min=0, value_max=180, comments='Value between 0 and 180.')
+        tparser.add_option(section, "motion_correction_mode", dtypes=["str"], default="bt", choice=["bt", "nav", "off"], comments='[bt, nav, off, ].')
 
         section = "ADCP_OUTPUT"
-        tparser.add_option(section, "merge_output_files", dtypes=[
-                           "bool"], default=True, null_value=False)
-        tparser.add_option(section, "bodc_name", dtypes=[
-                           "bool"], default=True, null_value=False)
-        tparser.add_option(section, "force_platform_metadata", dtypes=[
-                           "bool"], default=False, null_value=False)
-        tparser.add_option(section, "drop_percent_good", dtypes=[
-                           "bool"], default=True, null_value=False)
-        tparser.add_option(section, "drop_correlation", dtypes=[
-                           "bool"], default=True, null_value=False)
-        tparser.add_option(section, "drop_amplitude", dtypes=[
-                           "bool"], default=True, null_value=False)
-        tparser.add_option(section, "odf_data", dtypes=["str"], default="both", choice=[
-                           "vel", "anc", "both"], comments='One of [vel, anc, both,].')
-        tparser.add_option(section, "make_figures", dtypes=[
-                           "bool", "str"], default=True, null_value=False)
-        tparser.add_option(section, "make_log", dtypes=[
-                           "bool"], default=True, null_value=False)
-        tparser.add_option(section, "showfig", dtypes=[
-                           "bool"], default=True, null_value=True)
+        tparser.add_option(section, "merge_output_files", dtypes=["bool"], default=True, null_value=False)
+        tparser.add_option(section, "bodc_name", dtypes=["bool"], default=True, null_value=False)
+        tparser.add_option(section, "force_platform_metadata", dtypes=["bool"], default=False, null_value=False)
+        tparser.add_option(section, "drop_percent_good", dtypes=["bool"], default=True, null_value=False)
+        tparser.add_option(section, "drop_correlation", dtypes=["bool"], default=True, null_value=False)
+        tparser.add_option(section, "drop_amplitude", dtypes=["bool"], default=True, null_value=False)
+        tparser.add_option(section, "odf_data", dtypes=["str"], default="both", choice=["vel", "anc", "both"], comments='One of [vel, anc, both,].')
+        tparser.add_option(section, "make_figures", dtypes=["bool", "str"], default=True, null_value=False)
+        tparser.add_option(section, "make_log", dtypes=["bool"], default=True, null_value=False)
+        tparser.add_option(section, "showfig", dtypes=["bool"], default=True, null_value=True)
 
     return tparser
 

--- a/magtogoek/config_handler.py
+++ b/magtogoek/config_handler.py
@@ -247,7 +247,6 @@ def get_config_taskparser(sensor_type: Optional[str] = None):
         tparser.add_option(section, "odf_data", dtypes=["str"], default="both", choice=["vel", "anc", "both"], comments='One of [vel, anc, both,].')
         tparser.add_option(section, "make_figures", dtypes=["bool", "str"], default=True, null_value=False)
         tparser.add_option(section, "make_log", dtypes=["bool"], default=True, null_value=False)
-        tparser.add_option(section, "showfig", dtypes=["bool"], default=True, null_value=True)
 
     return tparser
 

--- a/magtogoek/config_handler.py
+++ b/magtogoek/config_handler.py
@@ -90,9 +90,11 @@ def write_configfile(filename: str, sensor_type: str, cli_options: Optional[dict
 
     cli_config = None
     if cli_options is not None:
-        cli_config = _format_cli_options_to_config_dict(sensor_type, tparser, cli_options)
+        cli_config = _format_cli_options_to_config_dict(
+            sensor_type, tparser, cli_options)
 
-    tparser.write_from_dict(filename=filename, parser_dict=cli_config, add_missing=True, format_options=False)
+    tparser.write_from_dict(
+        filename=filename, parser_dict=cli_config, add_missing=True, format_options=False)
 
 
 def load_configfile(filename: str, cli_options: Optional[dict] = None) -> ParserDict:
@@ -114,10 +116,12 @@ def load_configfile(filename: str, cli_options: Optional[dict] = None) -> Parser
 
     cli_config = None
     if cli_options is not None:
-        cli_config = _format_cli_options_to_config_dict(sensor_type, tparser, cli_options)
+        cli_config = _format_cli_options_to_config_dict(
+            sensor_type, tparser, cli_options)
 
-    config = tparser.load(filename, add_missing=True, new_values_dict=cli_config, format_options=True)
- 
+    config = tparser.load(filename, add_missing=True,
+                          new_values_dict=cli_config, format_options=True)
+
     return config, sensor_type
 
 
@@ -134,9 +138,11 @@ def cli_options_to_config(sensor_type: str, cli_options: dict, cwd: Optional[str
     """
     tparser = get_config_taskparser(sensor_type)
     config = tparser.as_dict(with_default=True)
-    cli_config = _format_cli_options_to_config_dict(sensor_type, tparser, cli_options)
+    cli_config = _format_cli_options_to_config_dict(
+        sensor_type, tparser, cli_options)
 
-    tparser.format_parser_dict(parser_dict=cli_config, add_missing=True, format_options=True, file_path=cwd)
+    tparser.format_parser_dict(
+        parser_dict=cli_config, add_missing=True, format_options=True, file_path=cwd)
 
     return cli_config
 
@@ -150,29 +156,40 @@ def get_config_taskparser(sensor_type: Optional[str] = None):
     tparser = TaskParser()
 
     section = "HEADER"
-    tparser.add_option(section, "made_by", dtypes=["str"], default=getpass.getuser())
-    tparser.add_option(section, "last_updated", dtypes=["str"], default=datetime.now().strftime("%Y-%m-%d"))
-    tparser.add_option(section, "sensor_type", dtypes=["str"], default=sensor_type, is_required=True, choice=["adcp"], comments='One of [adcp, ].')
-    tparser.add_option(section, "platform_type", dtypes=["str"], choice=["buoy", "mooring", "ship"], comments='One of [buoy, mooring, ship, ].')
+    tparser.add_option(section, "made_by", dtypes=[
+                       "str"], default=getpass.getuser())
+    tparser.add_option(section, "last_updated", dtypes=[
+                       "str"], default=datetime.now().strftime("%Y-%m-%d"))
+    tparser.add_option(section, "sensor_type", dtypes=[
+                       "str"], default=sensor_type, is_required=True, choice=["adcp"], comments='One of [adcp, ].')
+    tparser.add_option(section, "platform_type", dtypes=["str"], choice=[
+                       "buoy", "mooring", "ship"], comments='One of [buoy, mooring, ship, ].')
 
     section = "INPUT"
-    tparser.add_option(section, "input_files", dtypes=["str"], default="", nargs_min=1, is_file=True, is_required=True)
-    tparser.add_option(section, "platform_file", dtypes=["str"], default=None, is_file=True)
+    tparser.add_option(section, "input_files", dtypes=[
+                       "str"], default="", nargs_min=1, is_file=True, is_required=True)
+    tparser.add_option(section, "platform_file", dtypes=[
+                       "str"], default=None, is_file=True)
     tparser.add_option(section, "platform_id", dtypes=["str"], default=None)
     tparser.add_option(section, "sensor_id", dtypes=["str"], default=None)
 
     section = "OUTPUT"
-    tparser.add_option(section, "netcdf_output", dtypes=["str", "bool"], default="", is_path=True, null_value=False)
-    tparser.add_option(section, "odf_output", dtypes=["str", "bool"], default="", is_path=True, null_value=False)
+    tparser.add_option(section, "netcdf_output", dtypes=[
+                       "str", "bool"], default="", is_path=True, null_value=False)
+    tparser.add_option(section, "odf_output", dtypes=[
+                       "str", "bool"], default="", is_path=True, null_value=False)
 
     section = "NETCDF_CF"
-    tparser.add_option(section, "Conventions", dtypes=["str"], default="CF 1.8")
+    tparser.add_option(section, "Conventions", dtypes=[
+                       "str"], default="CF 1.8")
     tparser.add_option(section, "title", dtypes=["str"], default="")
     tparser.add_option(section, "institution", dtypes=["str"], default="")
     tparser.add_option(section, "summary", dtypes=["str"], default="")
-    tparser.add_option(section, "references", dtypes=["str"], default=REFERENCE)
+    tparser.add_option(section, "references", dtypes=[
+                       "str"], default=REFERENCE)
     tparser.add_option(section, "comments", dtypes=["str"], default="")
-    tparser.add_option(section, "naming_authority", dtypes=["str"], default="BODC, SDC, CF, MEDS")
+    tparser.add_option(section, "naming_authority", dtypes=[
+                       "str"], default="BODC, SDC, CF, MEDS")
     tparser.add_option(section, "source", dtypes=["str"], default="")
 
     section = "PROJECT"
@@ -181,16 +198,23 @@ def get_config_taskparser(sensor_type: Optional[str] = None):
     tparser.add_option(section, "sea_code", dtypes=["str"], default="")
 
     section = "CRUISE"
-    tparser.add_option(section, "country_institute_code", dtypes=["str"], default="")
-    tparser.add_option(section, "cruise_number", dtypes=["str"], default="", null_value="")
+    tparser.add_option(section, "country_institute_code",
+                       dtypes=["str"], default="")
+    tparser.add_option(section, "cruise_number", dtypes=[
+                       "str"], default="", null_value="")
     tparser.add_option(section, "cruise_name", dtypes=["str"], default="")
-    tparser.add_option(section, "cruise_description", dtypes=["str"], default="")
+    tparser.add_option(section, "cruise_description",
+                       dtypes=["str"], default="")
     tparser.add_option(section, "organization", dtypes=["str"], default="")
     tparser.add_option(section, "chief_scientist", dtypes=["str"], default="")
-    tparser.add_option(section, "start_date", dtypes=["str", "int"], default="", is_time_stamp=True)
-    tparser.add_option(section, "end_date", dtypes=["str", "int"], default="", is_time_stamp=True)
-    tparser.add_option(section, "event_number", dtypes=["str"], default="", null_value="")
-    tparser.add_option(section, "event_qualifier1", dtypes=["str"], default="", null_value="")
+    tparser.add_option(section, "start_date", dtypes=[
+                       "str", "int"], default="", is_time_stamp=True)
+    tparser.add_option(section, "end_date", dtypes=[
+                       "str", "int"], default="", is_time_stamp=True)
+    tparser.add_option(section, "event_number", dtypes=[
+                       "str"], default="", null_value="")
+    tparser.add_option(section, "event_qualifier1", dtypes=[
+                       "str"], default="", null_value="")
     tparser.add_option(section, "event_comments", dtypes=["str"], default="")
 
     section = "GLOBAL_ATTRIBUTES"
@@ -201,53 +225,90 @@ def get_config_taskparser(sensor_type: Optional[str] = None):
     tparser.add_option(section, "creator_type", dtypes=["str"], default="")
     tparser.add_option(section, "publisher_name", dtypes=["str"], default="")
     tparser.add_option(section, "keywords", dtypes=["str"], default="")
-    tparser.add_option(section, "keywords_vocabulary", dtypes=["str"], default="")
-    tparser.add_option(section, "standard_name_vocabulary", dtypes=["str"], default="CF v.52")
+    tparser.add_option(section, "keywords_vocabulary",
+                       dtypes=["str"], default="")
+    tparser.add_option(section, "standard_name_vocabulary",
+                       dtypes=["str"], default="CF v.52")
     tparser.add_option(section, "acknowledgment", dtypes=["str"], default="")
 
     if sensor_type == 'adcp':
         section = "ADCP_PROCESSING"
-        tparser.add_option(section, "yearbase", dtypes=["int"], default="", is_required=True)
-        tparser.add_option(section, "adcp_orientation", dtypes=["str"], default="down", choice=["up", "down"], comments='up or down')
+        tparser.add_option(section, "yearbase", dtypes=[
+                           "int"], default="", is_required=True)
+        tparser.add_option(section, "adcp_orientation", dtypes=[
+                           "str"], default="down", choice=["up", "down"], comments='up or down')
         tparser.add_option(section, "sonar", dtypes=["str"], choice=["wh", "sv", "os", "sw", "sw_pd0"], comments='[wh, sv, os, sw, sw_pd0, ]',
                            is_required=True)
-        tparser.add_option(section, "navigation_file", dtypes=["str"], default="", is_file=True)
-        tparser.add_option(section, "leading_trim", dtypes=["int", "str"], default="", is_time_stamp=True)
-        tparser.add_option(section, "trailing_trim", dtypes=["int", "str"], default="", is_time_stamp=True)
-        tparser.add_option(section, "sensor_depth", dtypes=["float"], default="")
-        tparser.add_option(section, "depth_range", dtypes=["float"], nargs_min=0, nargs_max=2)
-        tparser.add_option(section, "bad_pressure", dtypes=["bool"], default=False, null_value=False)
-        tparser.add_option(section, "magnetic_declination", dtypes=["float"], default="")
-        tparser.add_option(section, "keep_bt", dtypes=["bool"], default=True, null_value=False)
-        tparser.add_option(section, "start_time", dtypes=["str"], default="", is_time_stamp=True)
+        tparser.add_option(section, "navigation_file", dtypes=[
+                           "str"], default="", is_file=True)
+        tparser.add_option(section, "leading_trim", dtypes=[
+                           "int", "str"], default="", is_time_stamp=True)
+        tparser.add_option(section, "trailing_trim", dtypes=[
+                           "int", "str"], default="", is_time_stamp=True)
+        tparser.add_option(section, "sensor_depth",
+                           dtypes=["float"], default="")
+        tparser.add_option(section, "depth_range", dtypes=[
+                           "float"], nargs_min=0, nargs_max=2)
+        tparser.add_option(section, "bad_pressure", dtypes=[
+                           "bool"], default=False, null_value=False)
+        tparser.add_option(section, "magnetic_declination",
+                           dtypes=["float"], default="")
+        tparser.add_option(section, "keep_bt", dtypes=[
+                           "bool"], default=True, null_value=False)
+        tparser.add_option(section, "start_time", dtypes=[
+                           "str"], default="", is_time_stamp=True)
         tparser.add_option(section, "time_step", dtypes=["float"], default="")
-        tparser.add_option(section, "grid_depth", dtypes=["str"], default="", comments='Path to column grid file (m).', is_path=True, nargs_min=1)
-        tparser.add_option(section, "grid_method", dtypes=["str"], default="interp", choice=["interp", "bin"], comments='[interp, bin].')
+        tparser.add_option(section, "grid_depth", dtypes=[
+                           "str"], default="", comments='Path to column grid file (m).', is_path=True, nargs_min=1)
+        tparser.add_option(section, "grid_method", dtypes=[
+                           "str"], default="interp", choice=["interp", "bin"], comments='[interp, bin].')
 
         section = "ADCP_QUALITY_CONTROL"
-        tparser.add_option(section, "quality_control", dtypes=["bool"], default=True, null_value=False)
-        tparser.add_option(section, "amplitude_threshold", dtypes=["int"], default=0, value_min=0, value_max=255, comments='Value between 0 and 255.')
-        tparser.add_option(section, "percentgood_threshold", dtypes=["int"], default=64, value_min=0, value_max=100, comments='Value between 0 and 100.')
-        tparser.add_option(section, "correlation_threshold", dtypes=["int"], default=90, value_min=0, value_max=255, comments='Value between 0 and 255.')
-        tparser.add_option(section, "horizontal_velocity_threshold", dtypes=["float"], default=5)
-        tparser.add_option(section, "vertical_velocity_threshold", dtypes=["float"], default=5)
-        tparser.add_option(section, "error_velocity_threshold", dtypes=["float"], default=5)
-        tparser.add_option(section, "sidelobes_correction", dtypes=["bool"], default=True, null_value=False)
+        tparser.add_option(section, "quality_control", dtypes=[
+                           "bool"], default=True, null_value=False)
+        tparser.add_option(section, "amplitude_threshold", dtypes=[
+                           "int"], default=0, value_min=0, value_max=255, comments='Value between 0 and 255.')
+        tparser.add_option(section, "percentgood_threshold", dtypes=[
+                           "int"], default=64, value_min=0, value_max=100, comments='Value between 0 and 100.')
+        tparser.add_option(section, "correlation_threshold", dtypes=[
+                           "int"], default=90, value_min=0, value_max=255, comments='Value between 0 and 255.')
+        tparser.add_option(section, "horizontal_velocity_threshold", dtypes=[
+                           "float"], default=5)
+        tparser.add_option(section, "vertical_velocity_threshold", dtypes=[
+                           "float"], default=5)
+        tparser.add_option(section, "error_velocity_threshold",
+                           dtypes=["float"], default=5)
+        tparser.add_option(section, "sidelobes_correction", dtypes=[
+                           "bool"], default=True, null_value=False)
         tparser.add_option(section, "bottom_depth", dtypes=["float"])
-        tparser.add_option(section, "pitch_threshold", dtypes=["int"], default=20, value_min=0, value_max=180, comments='Value between 0 and 180.')
-        tparser.add_option(section, "roll_threshold", dtypes=["int"], default=20, value_min=0, value_max=180, comments='Value between 0 and 180.')
-        tparser.add_option(section, "motion_correction_mode", dtypes=["str"], default="bt", choice=["bt", "nav", "off"], comments='[bt, nav, off, ].')
+        tparser.add_option(section, "pitch_threshold", dtypes=[
+                           "int"], default=20, value_min=0, value_max=180, comments='Value between 0 and 180.')
+        tparser.add_option(section, "roll_threshold", dtypes=[
+                           "int"], default=20, value_min=0, value_max=180, comments='Value between 0 and 180.')
+        tparser.add_option(section, "motion_correction_mode", dtypes=[
+                           "str"], default="bt", choice=["bt", "nav", "off"], comments='[bt, nav, off, ].')
 
         section = "ADCP_OUTPUT"
-        tparser.add_option(section, "merge_output_files", dtypes=["bool"], default=True, null_value=False)
-        tparser.add_option(section, "bodc_name", dtypes=["bool"], default=True, null_value=False)
-        tparser.add_option(section, "force_platform_metadata", dtypes=["bool"], default=False, null_value=False)
-        tparser.add_option(section, "drop_percent_good", dtypes=["bool"], default=True, null_value=False)
-        tparser.add_option(section, "drop_correlation", dtypes=["bool"], default=True, null_value=False)
-        tparser.add_option(section, "drop_amplitude", dtypes=["bool"], default=True, null_value=False)
-        tparser.add_option(section, "odf_data", dtypes=["str"], default="both", choice=["vel", "anc", "both"], comments='One of [vel, anc, both,].')
-        tparser.add_option(section, "make_figures", dtypes=["bool", "str"], default=True, null_value=False)
-        tparser.add_option(section, "make_log", dtypes=["bool"], default=True, null_value=False)
+        tparser.add_option(section, "merge_output_files", dtypes=[
+                           "bool"], default=True, null_value=False)
+        tparser.add_option(section, "bodc_name", dtypes=[
+                           "bool"], default=True, null_value=False)
+        tparser.add_option(section, "force_platform_metadata", dtypes=[
+                           "bool"], default=False, null_value=False)
+        tparser.add_option(section, "drop_percent_good", dtypes=[
+                           "bool"], default=True, null_value=False)
+        tparser.add_option(section, "drop_correlation", dtypes=[
+                           "bool"], default=True, null_value=False)
+        tparser.add_option(section, "drop_amplitude", dtypes=[
+                           "bool"], default=True, null_value=False)
+        tparser.add_option(section, "odf_data", dtypes=["str"], default="both", choice=[
+                           "vel", "anc", "both"], comments='One of [vel, anc, both,].')
+        tparser.add_option(section, "make_figures", dtypes=[
+                           "bool", "str"], default=True, null_value=False)
+        tparser.add_option(section, "make_log", dtypes=[
+                           "bool"], default=True, null_value=False)
+        tparser.add_option(section, "showfig", dtypes=[
+                           "bool"], default=True, null_value=True)
 
     return tparser
 

--- a/test/adcp_process_test.py
+++ b/test/adcp_process_test.py
@@ -12,12 +12,14 @@ CONFIG_PATH = Path().cwd()
         ({'netcdf_output': True, 'odf_output': True}, True, True, INPUT_FILES, str(CONFIG_PATH), INPUT_FILES),
         ({'netcdf_output': True, 'odf_output': False}, True, False, INPUT_FILES, None, INPUT_FILES),
         ({'netcdf_output': False, 'odf_output': False}, True, False, INPUT_FILES, None, INPUT_FILES),
-        ({'netcdf_output': 'filename', 'odf_output': True}, True, True, str(CONFIG_PATH) + '/filename', str(CONFIG_PATH), str(CONFIG_PATH) + '/filename'),
+        (
+        {'netcdf_output': 'filename', 'odf_output': True}, True, True, str(CONFIG_PATH) + '/filename', str(CONFIG_PATH),
+        str(CONFIG_PATH) + '/filename'),
         ({'netcdf_output': '../magtogoek/filename_nc', 'odf_output': '../magtogoek/filename_odf'},
-          True, True, '../magtogoek/filename_nc', '../magtogoek/filename_odf', '../magtogoek/filename_nc',),
-        ({'netcdf_output': False, 'odf_output': 'filename'}, False, True, None, str(CONFIG_PATH) + '/filename', str(CONFIG_PATH) + '/filename'),
+         True, True, '../magtogoek/filename_nc', '../magtogoek/filename_odf', '../magtogoek/filename_nc',),
+        ({'netcdf_output': False, 'odf_output': 'filename'}, False, True, None, str(CONFIG_PATH) + '/filename',
+         str(CONFIG_PATH) + '/filename'),
         # ({'netcdf_output': '', 'odf_output': ''}, , , , ,),
-
     ],
 )
 def test_outputs(config_dict, netcdf_output, odf_output, netcdf_path, odf_path, log_path):
@@ -34,6 +36,25 @@ def test_outputs(config_dict, netcdf_output, odf_output, netcdf_path, odf_path, 
 
 def test_outputs_error():
     config_dict = {'input': {**{'input_files': INPUT_FILES},
-                             **{'netcdf_output': '../notafolder/filename','odf_output': False}}}
+                             **{'netcdf_output': '../notafolder/filename', 'odf_output': False}}}
     with pytest.raises(ValueError):
         ProcessConfig(config_dict=config_dict)
+
+
+@pytest.mark.parametrize(
+    "config_dict, figure_output, figure_path",
+    [
+        ({'netcdf_output': True, 'make_figures': True}, True, None),
+        ({'netcdf_output': True, 'make_figures': True, "headless": True}, True, INPUT_FILES),
+        ({'netcdf_output': True, 'make_figures': "../magtogoek"}, True, "../magtogoek/"+Path(INPUT_FILES).stem),
+        ({'netcdf_output': True, 'make_figures': "../magtogoek/my_figs"}, True, "../magtogoek/my_figs"),
+        ({'netcdf_output': 'filename', 'make_figures': "../magtogoek"}, True, "../magtogoek/filename"),
+        ({'netcdf_output': 'filename', 'make_figures': "my_figs"}, True, str(CONFIG_PATH.joinpath('my_figs'))),
+        ({'netcdf_output': 'filename', 'make_figures': "my_figs", "headless": True}, True, str(CONFIG_PATH.joinpath('my_figs'))),
+    ]
+)
+def test_figures_outputs(config_dict, figure_output, figure_path):
+    config_dict = {'input': {**{'input_files': INPUT_FILES}, **config_dict}}
+    pconfig = ProcessConfig(config_dict=config_dict)
+    assert pconfig.figures_output == figure_output
+    assert pconfig.figures_path == figure_path


### PR DESCRIPTION
The objective of this branch is to allow more flexibility in showing or saving quality control figures. This is done in two ways:

Process workflow:

- When setting `make_figures` as a string in the `.ini` file, figures are saved to disk.
- When setting `showfig` to `False` in the `.ini` file, figures are not displayed on screen.

Quick workflow:

- The command line option `--hide-figs` tells the software not to display the figures on screen.