### PR TITLE
Supply magnetic declination deployment setting for Rowetech data

### DIFF
--- a/magtogoek/adcp/loader.py
+++ b/magtogoek/adcp/loader.py
@@ -82,7 +82,7 @@ def load_adcp_binary(
     bad_pressure: bool = False,
     start_time: str = None,
     time_step: float = None,
-    magnetic_declination_setting: float = None,
+    magnetic_declination_preset: float = None,
 ) -> xr.Dataset:
     """Load RDI and RTI adcp data.
 
@@ -119,7 +119,7 @@ def load_adcp_binary(
         Use the parameter `time_step` to use a different time step than the one found in the adcp raw adcp file.
     time_step:
         Time step in seconds. Only use if a `start_time` value is provided.
-    magnetic_declination_setting :
+    magnetic_declination_preset :
         RTI binaries do not contain the magnetic declination set in the ADCPs
         program before deployment, so the value read is always null. Overwrite
         this (e.g., with the value from the program commands) by setting this
@@ -152,8 +152,8 @@ def load_adcp_binary(
         data = RtiReader(filenames=filenames).read(
             start_index=leading_index, stop_index=trailing_index
         )
-        if magnetic_declination_setting:
-            data.FL['EV'] = magnetic_declination_setting * 100
+        if magnetic_declination_preset is not None:
+            data.FL['EV'] = magnetic_declination_preset * 100
         l.logbook += rti_log.logbook
     elif sonar in RDI_SONAR:
         if sonar == "sw_pd0":

--- a/magtogoek/adcp/loader.py
+++ b/magtogoek/adcp/loader.py
@@ -82,6 +82,7 @@ def load_adcp_binary(
     bad_pressure: bool = False,
     start_time: str = None,
     time_step: float = None,
+    magnetic_declination_setting: float = None,
 ) -> xr.Dataset:
     """Load RDI and RTI adcp data.
 
@@ -118,6 +119,12 @@ def load_adcp_binary(
         Use the parameter `time_step` to use a different time step than the one found in the adcp raw adcp file.
     time_step:
         Time step in seconds. Only use if a `start_time` value is provided.
+    magnetic_declination_setting :
+        RTI binaries do not contain the magnetic declination set in the ADCPs
+        program before deployment, so the value read is always null. Overwrite
+        this (e.g., with the value from the program commands) by setting this
+        parameter.
+
     Returns
     -------
         Dataset with the loaded adcp data
@@ -145,6 +152,8 @@ def load_adcp_binary(
         data = RtiReader(filenames=filenames).read(
             start_index=leading_index, stop_index=trailing_index
         )
+        if magnetic_declination_setting:
+            data.FL['EV'] = magnetic_declination_setting * 100
         l.logbook += rti_log.logbook
     elif sonar in RDI_SONAR:
         if sonar == "sw_pd0":

--- a/magtogoek/adcp/loader.py
+++ b/magtogoek/adcp/loader.py
@@ -487,8 +487,7 @@ def load_adcp_binary(
     dataset.attrs["magnetic_declination"] = None
     if "FL" in data:
         if "EV" in data.FL:
-            if data.FL["EV"] != 0:
-                dataset.attrs["magnetic_declination"] = data.FL["EV"] / 100
+            dataset.attrs["magnetic_declination"] = data.FL["EV"] / 100
     dataset.attrs["magnetic_declination_units"] = "degree east"
 
     dataset.attrs["orientation"] = orientation

--- a/magtogoek/adcp/process.py
+++ b/magtogoek/adcp/process.py
@@ -208,6 +208,7 @@ class ProcessConfig:
     sensor_depth: float = None
     depth_range: list = None
     magnetic_declination: float = None
+    magnetic_declination_setting: float = None
     keep_bt: bool = None
     bad_pressure: bool = None
     start_time: str = None
@@ -557,6 +558,7 @@ def _load_adcp_data(pconfig: ProcessConfig) -> xr.Dataset:
         bad_pressure=pconfig.bad_pressure,
         start_time=pconfig.start_time,
         time_step=pconfig.time_step,
+        magnetic_declination_setting=pconfig.magnetic_declination_setting,
     )
 
     dataset = cut_bin_depths(dataset, pconfig.depth_range)

--- a/magtogoek/adcp/process.py
+++ b/magtogoek/adcp/process.py
@@ -303,11 +303,8 @@ def process_adcp(config: dict, drop_empty_attrs: bool = False):
 
     The actual data processing is carried out by _process_adcp_data.
     """
-    print("TOP OF process_adcp: grid_depth = '%s'" % config.grid_depth)
-
     pconfig = ProcessConfig(config)
     pconfig.drop_empty_attrs = drop_empty_attrs
-    print("AFTER PROCESSCONFIG in process_adcp: grid_depth = ", type(pconfig.grid_depth), pconfig.grid_depth)
 
     if pconfig.merge_output_files:
         _process_adcp_data(pconfig)
@@ -353,7 +350,6 @@ def _process_adcp_data(pconfig: ProcessConfig):
 
     """
     l.reset()
-    print("TOP OF _process_adcp_data: grid_depth = ", type(pconfig.grid_depth), pconfig.grid_depth)
     # ----------------- #
     # LOADING ADCP DATA #
     # ----------------- #

--- a/magtogoek/adcp/process.py
+++ b/magtogoek/adcp/process.py
@@ -208,7 +208,7 @@ class ProcessConfig:
     sensor_depth: float = None
     depth_range: list = None
     magnetic_declination: float = None
-    magnetic_declination_setting: float = None
+    magnetic_declination_preset: float = None
     keep_bt: bool = None
     bad_pressure: bool = None
     start_time: str = None
@@ -242,7 +242,7 @@ class ProcessConfig:
     odf_path: str = None
     log_path: str = None
 
-    grid_depth: str = None
+    grid_depth: tp.Union[str, bool] = None
     grid_method: str = None
 
     def __init__(self, config_dict: dict = None):
@@ -303,9 +303,11 @@ def process_adcp(config: dict, drop_empty_attrs: bool = False):
 
     The actual data processing is carried out by _process_adcp_data.
     """
+    print("TOP OF process_adcp: grid_depth = '%s'" % config.grid_depth)
 
     pconfig = ProcessConfig(config)
     pconfig.drop_empty_attrs = drop_empty_attrs
+    print("AFTER PROCESSCONFIG in process_adcp: grid_depth = ", type(pconfig.grid_depth), pconfig.grid_depth)
 
     if pconfig.merge_output_files:
         _process_adcp_data(pconfig)
@@ -351,7 +353,7 @@ def _process_adcp_data(pconfig: ProcessConfig):
 
     """
     l.reset()
-
+    print("TOP OF _process_adcp_data: grid_depth = ", type(pconfig.grid_depth), pconfig.grid_depth)
     # ----------------- #
     # LOADING ADCP DATA #
     # ----------------- #
@@ -558,7 +560,7 @@ def _load_adcp_data(pconfig: ProcessConfig) -> xr.Dataset:
         bad_pressure=pconfig.bad_pressure,
         start_time=pconfig.start_time,
         time_step=pconfig.time_step,
-        magnetic_declination_setting=pconfig.magnetic_declination_setting,
+        magnetic_declination_preset=pconfig.magnetic_declination_preset,
     )
 
     dataset = cut_bin_depths(dataset, pconfig.depth_range)

--- a/magtogoek/config_handler.py
+++ b/magtogoek/config_handler.py
@@ -218,11 +218,11 @@ def get_config_taskparser(sensor_type: Optional[str] = None):
         tparser.add_option(section, "depth_range", dtypes=["float"], nargs_min=0, nargs_max=2)
         tparser.add_option(section, "bad_pressure", dtypes=["bool"], default=False, null_value=False)
         tparser.add_option(section, "magnetic_declination", dtypes=["float"], default="")
-        tparser.add_option(section, "magnetic_declination_setting", dtypes=["float"], default="", comments="Found in the ADCP configuration file.")
+        tparser.add_option(section, "magnetic_declination_preset", dtypes=["float"], default=None, comments="Found in the ADCP configuration file.")
         tparser.add_option(section, "keep_bt", dtypes=["bool"], default=True, null_value=False)
         tparser.add_option(section, "start_time", dtypes=["str"], default="", is_time_stamp=True)
         tparser.add_option(section, "time_step", dtypes=["float"], default="")
-        tparser.add_option(section, "grid_depth", dtypes=["str"], default="", comments='Path to column grid file (m).', is_path=True, nargs_min=1)
+        tparser.add_option(section, "grid_depth", dtypes=["str"], default="", null_value=None, comments='Path to column grid file (m).', is_path=True)
         tparser.add_option(section, "grid_method", dtypes=["str"], default="interp", choice=["interp", "bin"], comments='[interp, bin].')
 
         section = "ADCP_QUALITY_CONTROL"

--- a/magtogoek/config_handler.py
+++ b/magtogoek/config_handler.py
@@ -218,6 +218,7 @@ def get_config_taskparser(sensor_type: Optional[str] = None):
         tparser.add_option(section, "depth_range", dtypes=["float"], nargs_min=0, nargs_max=2)
         tparser.add_option(section, "bad_pressure", dtypes=["bool"], default=False, null_value=False)
         tparser.add_option(section, "magnetic_declination", dtypes=["float"], default="")
+        tparser.add_option(section, "magnetic_declination_setting", dtypes=["float"], default="", comments="Found in the ADCP configuration file.")
         tparser.add_option(section, "keep_bt", dtypes=["bool"], default=True, null_value=False)
         tparser.add_option(section, "start_time", dtypes=["str"], default="", is_time_stamp=True)
         tparser.add_option(section, "time_step", dtypes=["float"], default="")


### PR DESCRIPTION
Data are rotated internally by RTI ADCPs during the deployment in accordance with the magnetic declination supplied by the CHO command. However, this information does not appear to be part of the resulting binaries. Since by default, if it can't find the magnetic declination, magtogoek assumes it was set to zero, supplying a value (e.g., via the `.ini` file) to the `magnetic_declination` parameter results in different behaviors for RDI and RTI binaries.

- RDI: this should be the final value; correct as needed with respect to the deployment setting.
- RTI: rotate by this angle.

This branch aims to make the be code behave as for RDI data in both cases by applying the following changes:

1. new parameter `magnetic_declination_setting` of the `ProcessConfig` object.
2. overwriting of the null `EV` value for RTI data by the `magnetic_declination_setting` parameter before magnetic declination correction.