### PR TITLE
Bodc update

### DIFF
--- a/TODO.org
+++ b/TODO.org
@@ -3,46 +3,13 @@
 
 * New BODC parameters:
 
-** ADCP code for raw velocity (relative to moving platform)
-
-*** ADCP Inconsistency
- - moored accoustic doppler current profile (ADCP) beam X exist but not for shipborne or lowered.
- - ADCP vs acoustic doppler current profiler(ADCP).
- - (lower adcp/moored adcp/shipborne) OR (by ADCP bottom tracking).
- - (Eulerian measurement) missing for (relative to moving platform). LCN... C -> eurelien ? R-> relative
-
-** ADCP beam velocity S for ship, LW for lowered.
-
- - (LCRRAP01) Radial velocity (away from) of water current (Eulerian measurement) in the water body by moored acoustic doppler current profiler (ADCP) beam 1
- - (LCRRAP02) Radial velocity (away from) of water current (Eulerian measurement) in the water body by moored acoustic doppler current profiler (ADCP) beam 2
- - (LCRRAP03) Radial velocity (away from) of water current (Eulerian measurement) in the water body by moored acoustic doppler current profiler (ADCP) beam 3
- - (LCRRAP04) Radial velocity (away from) of water current (Eulerian measurement) in the water body by moored acoustic doppler current profiler (ADCP) beam 4
-
-** ADCP beam bt velocity
- - (LCRRBT01) Radial velocity (away from) of water current (Eulerian measurement) in the water body by ADCP bottom tracking beam 1
- - (LCRRBT02) Radial velocity (away from) of water current (Eulerian measurement) in the water body by ADCP bottom tracking beam 2
- - (LCRRBT03) Radial velocity (away from) of water current (Eulerian measurement) in the water body by ADCP bottom tracking beam 3
- - (LCRRBT04) Radial velocity (away from) of water current (Eulerian measurement) in the water body by ADCP bottom tracking beam 4
-
-** ADCP xyz velocity (shipeborne S, lowered LW)
- - (LCXAAP01) Velocity along x-axis of water current (Eulerian measurement) in the water body by moored acoustic doppler current profiler (ADCP)
- - (LCYAAP01) Velocity along y-axis of water current (Eulerian measurement) in the water body by moored acoustic doppler current profiler (ADCP)
- - (LCZAAP01) Upward current velocity of water current (Eulerian measurement) in the water body by moored acoustic doppler current profiler (ADCP)
- - (LERRAP01) Upward current velocity of water current (Eulerian measurement) in the water body by moored acoustic doppler current profiler (ADCP)
-
-** ADCP xyz bt velocity
- - (LCXABT01) Velocity along x-axis of water current (Eulerian measurement) in the water body by ADCP bottom tracking
- - (LCYABT01) Velocity along y-axis of water current (Eulerian measurement) in the water body by ADCP bottom tracking
- - (LCZABT01) Upward current velocity of water current (Eulerian measurement) in the water body by ADCP bottom tracking
- - (LERRBT01) Current velocity error the water body by ADCP bottom tracking
-
-** ADCP enu bt velocity
+** ADCP enu bt velocity. These CODE don't exist (yet)
  - (LRZABT01) Upward velocity of water current (Eulerian measurement) in the water body by ADCP bottom tracking
  - (LERRBT01) Upward velocity of water current (Eulerian measurement) in the water body by ADCP bottom tracking
 
 * Issues.
 ** Motion Correction in Adcp adcp/quality_control.py and load_navigation in navigation.
-   A fix has been added in vicking_dat branche.
+   A fix has been added in viking_dat branch.
    The load_navigation can return None if lon, lat are missing from the files which will crash in quality_control.py.
    Furthermore, the motion_correction function in quality_control.py needs to have longitude (and latitude) data to check for finite values.
    The code can crash there also since there is no if or else.

--- a/TODO.org
+++ b/TODO.org
@@ -3,42 +3,38 @@
 
 * New BODC parameters:
 
+** ADCP code for raw velocity (relative to moving platform)
+
 *** ADCP Inconsistency
+ - moored accoustic doppler current profile (ADCP) beam X exist but not for shipborne or lowered.
  - ADCP vs acoustic doppler current profiler(ADCP).
- - (lower adcp/moored adcp/shipborne) not used for (by ADCP bottom tracking).
- - (Eulerian measurement) missing for (relative to moving platform).
+ - (lower adcp/moored adcp/shipborne) OR (by ADCP bottom tracking).
+ - (Eulerian measurement) missing for (relative to moving platform). LCN... C -> eurelien ? R-> relative
 
-** ADCP Lagrangian velocities for drift()
- - (LRZALA01 ?) "Upward velocity of water current (Lagrangian measurement) in the water body by tracked drifting buoy"
+** ADCP beam velocity S for ship, LW for lowered.
 
-** ADCP beam velocity
- - Radial velocity (away from) of water current in the water body by moored acoustic doppler current profiler (ADCP) beam 1
- - Radial velocity (away from) of water current in the water body by moored acoustic doppler current profiler (ADCP) beam 2
- - Radial velocity (away from) of water current in the water body by moored acoustic doppler current profiler (ADCP) beam 3
- - Radial velocity (away from) of water current in the water body by moored acoustic doppler current profiler (ADCP) beam 4
-** ADCP beam velocity raw (maybe) ?
-- add 'relative to moving platform'
+ - (LCRRAP01) Radial velocity (away from) of water current (Eulerian measurement) in the water body by moored acoustic doppler current profiler (ADCP) beam 1
+ - (LCRRAP02) Radial velocity (away from) of water current (Eulerian measurement) in the water body by moored acoustic doppler current profiler (ADCP) beam 2
+ - (LCRRAP03) Radial velocity (away from) of water current (Eulerian measurement) in the water body by moored acoustic doppler current profiler (ADCP) beam 3
+ - (LCRRAP04) Radial velocity (away from) of water current (Eulerian measurement) in the water body by moored acoustic doppler current profiler (ADCP) beam 4
 
 ** ADCP beam bt velocity
- - Radial velocity (away from) of water current in the water body by ADCP bottom tracking beam 1
- - Radial velocity (away from) of water current in the water body by ADCP bottom tracking beam 2
- - Radial velocity (away from) of water current in the water body by ADCP bottom tracking beam 3
- - Radial velocity (away from) of water current in the water body by ADCP bottom tracking beam 4
+ - (LCRRBT01) Radial velocity (away from) of water current (Eulerian measurement) in the water body by ADCP bottom tracking beam 1
+ - (LCRRBT02) Radial velocity (away from) of water current (Eulerian measurement) in the water body by ADCP bottom tracking beam 2
+ - (LCRRBT03) Radial velocity (away from) of water current (Eulerian measurement) in the water body by ADCP bottom tracking beam 3
+ - (LCRRBT04) Radial velocity (away from) of water current (Eulerian measurement) in the water body by ADCP bottom tracking beam 4
 
-** ADCP xyz velocity
- - Velocity along x-axis of water current in the water body by acoustic doppler current profiler (ADCP)
- - Velocity along y-axis of water current in the water body by acoustic doppler current profiler (ADCP)
- - Upward current velocity of water current in the water body by acoustic doppler current profiler (ADCP)
-** ADCP xyz velocity raw
- - add 'relative to moving platform'
+** ADCP xyz velocity (shipeborne S, lowered LW)
+ - (LCXAAP01) Velocity along x-axis of water current (Eulerian measurement) in the water body by moored acoustic doppler current profiler (ADCP)
+ - (LCYAAP01) Velocity along y-axis of water current (Eulerian measurement) in the water body by moored acoustic doppler current profiler (ADCP)
+ - (LCZAAP01) Upward current velocity of water current (Eulerian measurement) in the water body by moored acoustic doppler current profiler (ADCP)
+ - (LERRAP01) Upward current velocity of water current (Eulerian measurement) in the water body by moored acoustic doppler current profiler (ADCP)
 
 ** ADCP xyz bt velocity
- - Velocity along x-axis of water current in the water body by ADCP bottom tracking
- - Velocity along y-axis of water current in the water body by ADCP bottom tracking
- - Upward current velocity of water current in the water body by ADCP bottom tracking
-
-** ADCP enu velocity raw
- - Upward velocity of water current relative to moving platform in the water body by shipborne acoustic doppler current profiler (ADCP)
+ - (LCXABT01) Velocity along x-axis of water current (Eulerian measurement) in the water body by ADCP bottom tracking
+ - (LCYABT01) Velocity along y-axis of water current (Eulerian measurement) in the water body by ADCP bottom tracking
+ - (LCZABT01) Upward current velocity of water current (Eulerian measurement) in the water body by ADCP bottom tracking
+ - (LERRBT01) Current velocity error the water body by ADCP bottom tracking
 
 ** ADCP enu bt velocity
  - (LRZABT01) Upward velocity of water current (Eulerian measurement) in the water body by ADCP bottom tracking

--- a/TODO.org
+++ b/TODO.org
@@ -1,6 +1,49 @@
 #+Author: jerome.guay@protonmail.com
 #+TITLE: Notes on Magtogoek
 
+* New BODC parameters:
+
+*** ADCP Inconsistency
+ - ADCP vs acoustic doppler current profiler(ADCP).
+ - (lower adcp/moored adcp/shipborne) not used for (by ADCP bottom tracking).
+ - (Eulerian measurement) missing for (relative to moving platform).
+
+** ADCP Lagrangian velocities for drift()
+ - (LRZALA01 ?) "Upward velocity of water current (Lagrangian measurement) in the water body by tracked drifting buoy"
+
+** ADCP beam velocity
+ - Radial velocity (away from) of water current in the water body by moored acoustic doppler current profiler (ADCP) beam 1
+ - Radial velocity (away from) of water current in the water body by moored acoustic doppler current profiler (ADCP) beam 2
+ - Radial velocity (away from) of water current in the water body by moored acoustic doppler current profiler (ADCP) beam 3
+ - Radial velocity (away from) of water current in the water body by moored acoustic doppler current profiler (ADCP) beam 4
+** ADCP beam velocity raw (maybe) ?
+- add 'relative to moving platform'
+
+** ADCP beam bt velocity
+ - Radial velocity (away from) of water current in the water body by ADCP bottom tracking beam 1
+ - Radial velocity (away from) of water current in the water body by ADCP bottom tracking beam 2
+ - Radial velocity (away from) of water current in the water body by ADCP bottom tracking beam 3
+ - Radial velocity (away from) of water current in the water body by ADCP bottom tracking beam 4
+
+** ADCP xyz velocity
+ - Velocity along x-axis of water current in the water body by acoustic doppler current profiler (ADCP)
+ - Velocity along y-axis of water current in the water body by acoustic doppler current profiler (ADCP)
+ - Upward current velocity of water current in the water body by acoustic doppler current profiler (ADCP)
+** ADCP xyz velocity raw
+ - add 'relative to moving platform'
+
+** ADCP xyz bt velocity
+ - Velocity along x-axis of water current in the water body by ADCP bottom tracking
+ - Velocity along y-axis of water current in the water body by ADCP bottom tracking
+ - Upward current velocity of water current in the water body by ADCP bottom tracking
+
+** ADCP enu velocity raw
+ - Upward velocity of water current relative to moving platform in the water body by shipborne acoustic doppler current profiler (ADCP)
+
+** ADCP enu bt velocity
+ - (LRZABT01) Upward velocity of water current (Eulerian measurement) in the water body by ADCP bottom tracking
+ - (LERRBT01) Upward velocity of water current (Eulerian measurement) in the water body by ADCP bottom tracking
+
 * Issues.
 ** Motion Correction in Adcp adcp/quality_control.py and load_navigation in navigation.
    A fix has been added in vicking_dat branche.

--- a/magtogoek/adcp/process.py
+++ b/magtogoek/adcp/process.py
@@ -104,6 +104,8 @@ DEFAULT_PLATFORM_TYPE = "buoy"
 DATA_TYPES = {"buoy": "madcp", "mooring": "madcp", "ship": "adcp"}
 DATA_SUBTYPES = {"buoy": "BUOY", "mooring": "MOORED", "ship": "SHIPBORNE"}
 
+# TODO FIXME lowered adcp SDNSLW01, LCEWLW01, SDZALW01, ERRVLDCP NEW BRANCHE NEEED
+
 P01_VEL_CODES = dict(
     buoy=dict(
         u="LCEWAP01",
@@ -115,9 +117,9 @@ P01_VEL_CODES = dict(
         w_QC="LRZAAP01_QC",
     ),
     ship=dict(
-        u="LCEWAS01",
-        v="LCNSAS01",
-        w="LRZAAS01",
+        u="LCEWAS01",  # LREWAS01 if not motion corrected
+        v="LCNSAS01",  # LRNSAS01 if not motion corrected
+        w="LRZAAS01",  # DOES NOT EXIST FOR MOTION CORRECTED
         e="LERRAS01",
         u_QC="LCEWAS01_QC",
         v_QC="LCNSAS01_QC",
@@ -141,10 +143,10 @@ P01_CODES = dict(
     amp2="TNIHCE02",
     amp3="TNIHCE03",
     amp4="TNIHCE04",
-    bt_u="APEWBT01",
-    bt_v="APNSBT01",
-    bt_w="APZABT01",
-    bt_e="APERBT01",
+    bt_u="LCEWBT01",
+    bt_v="LCNSBT01",
+    bt_w="LRZABT01", #FIXME Do not yet exist as a BODC sdn code
+    bt_e="LERRBT01", #FIXME Do not yet exist as a BODC sdn code
     vb_vel="LRZUVP01",
     vb_vel_QC="LRZUVP01_QC",
     vb_pg="PCGDAP05",
@@ -466,7 +468,7 @@ def _process_adcp_data(pconfig: ProcessConfig):
     dataset.attrs["P01_CODES"] = {
         **P01_VEL_CODES[pconfig.platform_type],
         **P01_CODES,
-    }
+    } # TODO MAKE DUMMY CODE FOR VEL NOT IN EARTH ?
     dataset.attrs["variables_gen_name"] = [var for var in dataset.variables]  # For Odf outputs
 
     l.section("Variables attributes")

--- a/magtogoek/app.py
+++ b/magtogoek/app.py
@@ -217,7 +217,7 @@ def config_adcp(
 )
 @click.option("-y", "--yearbase", type=click.INT,
               help="""year when the adcp sampling started. ex: `1970`""", required=True)
-@click.option("-T", "--platform_type", type=click.Choice(["buoy", "mooring", "ship"]),
+@click.option("-T", "--platform_type", type=click.Choice(["buoy", "mooring", "ship", "lowered"]),
               help="Used for Proper BODC variables names", default="buoy")
 @click.option("--headless",
               is_flag=True,

--- a/magtogoek/config_handler.py
+++ b/magtogoek/config_handler.py
@@ -153,7 +153,7 @@ def get_config_taskparser(sensor_type: Optional[str] = None):
     tparser.add_option(section, "made_by", dtypes=["str"], default=getpass.getuser())
     tparser.add_option(section, "last_updated", dtypes=["str"], default=datetime.now().strftime("%Y-%m-%d"))
     tparser.add_option(section, "sensor_type", dtypes=["str"], default=sensor_type, is_required=True, choice=["adcp"], comments='One of [adcp, ].')
-    tparser.add_option(section, "platform_type", dtypes=["str"], choice=["buoy", "mooring", "ship"], comments='One of [buoy, mooring, ship, ].')
+    tparser.add_option(section, "platform_type", dtypes=["str"], choice=["buoy", "mooring", "ship", "lowered"], comments='One of [buoy, mooring, ship, ].')
 
     section = "INPUT"
     tparser.add_option(section, "input_files", dtypes=["str"], default="", nargs_min=1, is_file=True, is_required=True)

--- a/magtogoek/files/CF_P01_GF3_formats.json
+++ b/magtogoek/files/CF_P01_GF3_formats.json
@@ -49,6 +49,7 @@
         "sdn_uom_name": "Metres per second",
         "legacy_GF3_code": "SDN:GF3::ERRV"
     },
+
     "LCEWAS01": {
         "standard_name": "eastward_sea_water_velocity",
         "units": "m s-1",
@@ -92,6 +93,67 @@
         "sdn_uom_name": "Metres per second",
         "legacy_GF3_code": "SDN:GF3::ERRV"
     },
+
+    "LREWAS01": {
+        "standard_name": "eastward_sea_water_velocity",
+        "units": "m s-1",
+        "sensor_type": "adcp",
+        "long_name": "eastward sea water velocity",
+        "sdn_parameter_urn": "SDN:P01::LREWAS01",
+        "sdn_parameter_name": "Eastward velocity of water current relative to moving platform in the water body by shipborne acoustic doppler current profiler (ADCP)",
+        "sdn_uom_urn": "SDN:P06::UVAA",
+        "sdn_uom_name": "Metres per second",
+        "legacy_GF3_code": "SDN:GF3::EWCT"
+    },
+    "LRNSAS01": {
+        "standard_name": "northward_sea_water_velocity",
+        "units": "m s-1",
+        "sensor_type": "adcp",
+        "long_name": "northward sea water velocity",
+        "sdn_parameter_urn": "SDN:P01::LRNSAS01",
+        "sdn_parameter_name": "Northward velocity of water current relative to moving platform in the water body by shipborne acoustic doppler current profiler (ADCP)",
+        "sdn_uom_urn": "SDN:P06::UVAA",
+        "sdn_uom_name": "Metres per second",
+        "legacy_GF3_code": "SDN:GF3::NWCT"
+    },
+    "LCNSBT01": {
+        "units": "m s-1",
+        "sensor_type": "adcp",
+        "long_name": "northward velocity of the seabed",
+        "sdn_parameter_urn": "SDN:P01::LCNSBT01",
+        "sdn_parameter_name": "Northward velocity of water current (Eulerian measurement) in the water body by ADCP bottom tracking",
+        "sdn_uom_urn": "SDN:P06::UVAA",
+        "sdn_uom_name": "Metres per second"
+    },
+    "LCEWBT01": {
+        "units": "m s-1",
+        "sensor_type": "adcp",
+        "long_name": "eastward velocity of the seabed",
+        "sdn_parameter_urn": "SDN:P01::LCEWBT01",
+        "sdn_parameter_name": "Eastward velocity of water current (Eulerian measurement) in the water body by ADCP bottom tracking",
+        "sdn_uom_urn": "SDN:P06::UVAA",
+        "sdn_uom_name": "Metres per second"
+    },
+    "LRZABT01": {
+        "units": "m s-1",
+        "sensor_type": "adcp",
+        "long_name": "upward velocity of the seabed",
+        "sdn_parameter_urn": "SDN:P01::LRZABT01",
+        "sdn_parameter_name": "Upward velocity of water current (Eulerian measurement) in the water body by ADCP bottom tracking",
+        "sdn_uom_urn": "SDN:P06::UVAA",
+        "sdn_uom_name": "Metres per second"
+    },
+    "LERRBT01": {
+        "units": "m s-1",
+        "sensor_type": "adcp",
+        "long_name": "error velocity of the seabed",
+        "sdn_parameter_urn": "SDN:P01::LERRBT01",
+        "sdn_parameter_name": "Current velocity error in the water body by ADCP bottom tracking",
+        "sdn_uom_urn": "SDN:P06::UVAA",
+        "sdn_uom_name": "Metres per second"
+    },
+
+
     "TNIHCE01": {
         "standard_name": "signal_intensity_from_multibeam_acoustic_doppler_velocity_sensor_in_sea_water",
         "units": "counts",
@@ -357,7 +419,7 @@
         "sensor_type": "adcp",
         "long_name": "bin depth below surface",
         "sdn_parameter_urn": "SDN:P01::PPSAADCP",
-        "sdn_parameter_name": "Depth below surface of the water body by acoustic doppler current profiler (ADCP) and computation from traveltime averaged from all operational beams and unknown sound velocity profile",
+        "sdn_parameter_name": "Depth below surface of the water body by acoustic doppler current profiler (ADCP) and computation from travel time averaged from all operational beams and unknown sound velocity profile",
         "sdn_uom_urn": "SDN:P06::ULAA",
         "sdn_uom_name": "Metres",
         "legacy_GF3_code": "SDN:GF3::DEPH"

--- a/magtogoek/files/CF_P01_GF3_formats.json
+++ b/magtogoek/files/CF_P01_GF3_formats.json
@@ -6,6 +6,199 @@
         "SDN:P06::",
         "SDN:GF3"
     ],
+
+    "vel_beam_1": {
+        "units": "m s-1",
+        "sensor_type": "adcp",
+        "long_name": "sea water velocity along beam 1",
+        "sdn_parameter_urn": "SDN:P01::XXXXXXXX",
+        "sdn_parameter_name": "",
+        "sdn_uom_urn": "SDN:P06::UVAA",
+        "sdn_uom_name": "Metres per second"
+    },
+    "vel_beam_2": {
+        "units": "m s-1",
+        "sensor_type": "adcp",
+        "long_name": "sea water velocity along beam 2",
+        "sdn_parameter_urn": "SDN:P01::XXXXXXXX",
+        "sdn_parameter_name": "",
+        "sdn_uom_urn": "SDN:P06::UVAA",
+        "sdn_uom_name": "Metres per second"
+    },
+    "vel_beam_3": {
+        "units": "m s-1",
+        "sensor_type": "adcp",
+        "long_name": "sea water velocity along beam 3",
+        "sdn_parameter_urn": "SDN:P01::XXXXXXXX",
+        "sdn_parameter_name": "",
+        "sdn_uom_urn": "SDN:P06::UVAA",
+        "sdn_uom_name": "Metres per second"
+    },
+    "vel_beam_4": {
+        "units": "m s-1",
+        "sensor_type": "adcp",
+        "long_name": "sea water velocity along beam 4",
+        "sdn_parameter_urn": "SDN:P01::XXXXXXXX",
+        "sdn_parameter_name": "",
+        "sdn_uom_urn": "SDN:P06::UVAA",
+        "sdn_uom_name": "Metres per second"
+    },
+
+    "bt_vel_beam_1": {
+        "units": "m s-1",
+        "sensor_type": "adcp",
+        "long_name": "seabed velocity along beam 1",
+        "sdn_parameter_urn": "SDN:P01::XXXXXXXX",
+        "sdn_parameter_name": "",
+        "sdn_uom_urn": "SDN:P06::UVAA",
+        "sdn_uom_name": "Metres per second"
+    },
+    "bt_vel_beam_2": {
+        "units": "m s-1",
+        "sensor_type": "adcp",
+        "long_name": "seabed velocity along beam 2",
+        "sdn_parameter_urn": "SDN:P01::XXXXXXXX",
+        "sdn_parameter_name": "",
+        "sdn_uom_urn": "SDN:P06::UVAA",
+        "sdn_uom_name": "Metres per second"
+    },
+    "bt_vel_beam_3": {
+        "units": "m s-1",
+        "sensor_type": "adcp",
+        "long_name": "seabed velocity along beam 3",
+        "sdn_parameter_urn": "SDN:P01::XXXXXXXX",
+        "sdn_parameter_name": "",
+        "sdn_uom_urn": "SDN:P06::UVAA",
+        "sdn_uom_name": "Metres per second"
+    },
+    "bt_vel_beam_4": {
+        "units": "m s-1",
+        "sensor_type": "adcp",
+        "long_name": "seabed velocity along beam 4",
+        "sdn_parameter_urn": "SDN:P01::XXXXXXXX",
+        "sdn_parameter_name": "",
+        "sdn_uom_urn": "SDN:P06::UVAA",
+        "sdn_uom_name": "Metres per second"
+    },
+
+    "vel_x_axis": {
+        "units": "m s-1",
+        "sensor_type": "adcp",
+        "long_name": "sea water velocity along the x-axis",
+        "sdn_parameter_urn": "SDN:P01::XXXXXXXX",
+        "sdn_parameter_name": "",
+        "sdn_uom_urn": "SDN:P06::UVAA",
+        "sdn_uom_name": "Metres per second"
+    },
+    "vel_y_axis": {
+        "units": "m s-1",
+        "sensor_type": "adcp",
+        "long_name": "sea water velocity along the y-axis",
+        "sdn_parameter_urn": "SDN:P01::XXXXXXXX",
+        "sdn_parameter_name": "",
+        "sdn_uom_urn": "SDN:P06::UVAA",
+        "sdn_uom_name": "Metres per second"
+    },
+    "vel_z_axis": {
+        "units": "m s-1",
+        "sensor_type": "adcp",
+        "long_name": "sea water velocity along the z-axis",
+        "sdn_parameter_urn": "SDN:P01::XXXXXXXX",
+        "sdn_parameter_name": "",
+        "sdn_uom_urn": "SDN:P06::UVAA",
+        "sdn_uom_name": "Metres per second"
+    },
+    "vel_e": {
+        "units": "m s-1",
+        "sensor_type": "adcp",
+        "long_name": "sea water velocity error",
+        "sdn_parameter_urn": "SDN:P01::XXXXXXXX",
+        "sdn_parameter_name": "",
+        "sdn_uom_urn": "SDN:P06::UVAA",
+        "sdn_uom_name": "Metres per second"
+    },
+
+    "bt_vel_x_axis": {
+        "units": "m s-1",
+        "sensor_type": "adcp",
+        "long_name": "seabed velocity along the x-axis",
+        "sdn_parameter_urn": "SDN:P01::XXXXXXXX",
+        "sdn_parameter_name": "",
+        "sdn_uom_urn": "SDN:P06::UVAA",
+        "sdn_uom_name": "Metres per second"
+    },
+    "bt_vel_y_axis": {
+        "units": "m s-1",
+        "sensor_type": "adcp",
+        "long_name": "seabed velocity along the y-axis",
+        "sdn_parameter_urn": "SDN:P01::XXXXXXXX",
+        "sdn_parameter_name": "",
+        "sdn_uom_urn": "SDN:P06::UVAA",
+        "sdn_uom_name": "Metres per second"
+    },
+    "bt_vel_z_axis": {
+        "units": "m s-1",
+        "sensor_type": "adcp",
+        "long_name": "seabed velocity along the z-axis",
+        "sdn_parameter_urn": "SDN:P01::XXXXXXXX",
+        "sdn_parameter_name": "",
+        "sdn_uom_urn": "SDN:P06::UVAA",
+        "sdn_uom_name": "Metres per second"
+    },
+    "bt_vel_e": {
+        "units": "m s-1",
+        "sensor_type": "adcp",
+        "long_name": "seabed velocity error",
+        "sdn_parameter_urn": "SDN:P01::XXXXXXXX",
+        "sdn_parameter_name": "",
+        "sdn_uom_urn": "SDN:P06::UVAA",
+        "sdn_uom_name": "Metres per second"
+    },
+
+    "LCEWLW01": {
+        "standard_name": "eastward_sea_water_velocity",
+        "units": "m s-1",
+        "sensor_type": "adcp",
+        "long_name": "eastward sea water velocity",
+        "sdn_parameter_urn": "SDN:P01::LCEWLW01",
+        "sdn_parameter_name": "Eastward current velocity (Eulerian measurement) in the water body by lowered acoustic doppler current profiler (ADCP)",
+        "sdn_uom_urn": "SDN:P06::UVAA",
+        "sdn_uom_name": "Metres per second",
+        "legacy_GF3_code": "SDN:GF3::EWCT"
+    },
+    "LCNSLW01": {
+        "standard_name": "northward_sea_water_velocity",
+        "units": "m s-1",
+        "sensor_type": "adcp",
+        "long_name": "northward sea water velocity",
+        "sdn_parameter_urn": "SDN:P01::LCNSLW01",
+        "sdn_parameter_name": "Northward current velocity (Eulerian measurement) in the water body by lowered acoustic doppler current profiler (ADCP)",
+        "sdn_uom_urn": "SDN:P06::UVAA",
+        "sdn_uom_name": "Metres per second",
+        "legacy_GF3_code": "SDN:GF3::NWCT"
+    },
+    "LRZALW01": {
+        "standard_name": "upward_sea_water_velocity",
+        "units": "m s-1",
+        "sensor_type": "adcp",
+        "long_name": "upward sea water velocity",
+        "sdn_parameter_urn": "SDN:P01::LRZALW01",
+        "sdn_parameter_name": "Upward current velocity (Eulerian measurement) in the water body by lowered acoustic doppler current profiler (ADCP)",
+        "sdn_uom_urn": "SDN:P06::UVAA",
+        "sdn_uom_name": "Metres per second",
+        "legacy_GF3_code": "SDN:GF3::VCSP"
+    },
+    "ERRVLW01": {
+        "units": "m s-1",
+        "sensor_type": "adcp",
+        "long_name": "error velocity in sea water",
+        "sdn_parameter_urn": "SDN:P01::LERRLW01",
+        "sdn_parameter_name": "Current velocity error in the water body by lowered acoustic doppler current profiler(ADCP)",
+        "sdn_uom_urn": "SDN:P06::UVAA",
+        "sdn_uom_name": "Metres per second",
+        "legacy_GF3_code": "SDN:GF3::ERRV"
+    },
+
     "LCEWAP01": {
         "standard_name": "eastward_sea_water_velocity",
         "units": "m s-1",
@@ -94,32 +287,10 @@
         "legacy_GF3_code": "SDN:GF3::ERRV"
     },
 
-    "LREWAS01": {
-        "standard_name": "eastward_sea_water_velocity",
-        "units": "m s-1",
-        "sensor_type": "adcp",
-        "long_name": "eastward sea water velocity",
-        "sdn_parameter_urn": "SDN:P01::LREWAS01",
-        "sdn_parameter_name": "Eastward velocity of water current relative to moving platform in the water body by shipborne acoustic doppler current profiler (ADCP)",
-        "sdn_uom_urn": "SDN:P06::UVAA",
-        "sdn_uom_name": "Metres per second",
-        "legacy_GF3_code": "SDN:GF3::EWCT"
-    },
-    "LRNSAS01": {
-        "standard_name": "northward_sea_water_velocity",
-        "units": "m s-1",
-        "sensor_type": "adcp",
-        "long_name": "northward sea water velocity",
-        "sdn_parameter_urn": "SDN:P01::LRNSAS01",
-        "sdn_parameter_name": "Northward velocity of water current relative to moving platform in the water body by shipborne acoustic doppler current profiler (ADCP)",
-        "sdn_uom_urn": "SDN:P06::UVAA",
-        "sdn_uom_name": "Metres per second",
-        "legacy_GF3_code": "SDN:GF3::NWCT"
-    },
     "LCNSBT01": {
         "units": "m s-1",
         "sensor_type": "adcp",
-        "long_name": "northward velocity of the seabed",
+        "long_name": "northward seabed velocity",
         "sdn_parameter_urn": "SDN:P01::LCNSBT01",
         "sdn_parameter_name": "Northward velocity of water current (Eulerian measurement) in the water body by ADCP bottom tracking",
         "sdn_uom_urn": "SDN:P06::UVAA",
@@ -128,7 +299,7 @@
     "LCEWBT01": {
         "units": "m s-1",
         "sensor_type": "adcp",
-        "long_name": "eastward velocity of the seabed",
+        "long_name": "eastward seabed velocity",
         "sdn_parameter_urn": "SDN:P01::LCEWBT01",
         "sdn_parameter_name": "Eastward velocity of water current (Eulerian measurement) in the water body by ADCP bottom tracking",
         "sdn_uom_urn": "SDN:P06::UVAA",
@@ -137,7 +308,7 @@
     "LRZABT01": {
         "units": "m s-1",
         "sensor_type": "adcp",
-        "long_name": "upward velocity of the seabed",
+        "long_name": "upward seabed velocity",
         "sdn_parameter_urn": "SDN:P01::LRZABT01",
         "sdn_parameter_name": "Upward velocity of water current (Eulerian measurement) in the water body by ADCP bottom tracking",
         "sdn_uom_urn": "SDN:P06::UVAA",
@@ -146,13 +317,12 @@
     "LERRBT01": {
         "units": "m s-1",
         "sensor_type": "adcp",
-        "long_name": "error velocity of the seabed",
+        "long_name": "seabed error velocity",
         "sdn_parameter_urn": "SDN:P01::LERRBT01",
         "sdn_parameter_name": "Current velocity error in the water body by ADCP bottom tracking",
         "sdn_uom_urn": "SDN:P06::UVAA",
         "sdn_uom_name": "Metres per second"
     },
-
 
     "TNIHCE01": {
         "standard_name": "signal_intensity_from_multibeam_acoustic_doppler_velocity_sensor_in_sea_water",


### PR DESCRIPTION
+ adcp bottom velocities BODC parameter codes replaced with appropriate ones. 
++ Codes for bt_w and bt_e (LRZABT01, LERRBT01) are not part of the official BODC vocabulary.
+ Adding platform type: "lowered".
++ BOD parameters added for "lowered" adcp.
+ Fake BODC P01 parameter codes added for adcp in beam or xyz coordinates. 
++ These code will be used if data are not transformed in earth coordinate instead of the ENU velocities. BODC parameter codes.